### PR TITLE
Bug Fix #96

### DIFF
--- a/Phergie/Plugin/Cron.php
+++ b/Phergie/Plugin/Cron.php
@@ -130,7 +130,7 @@ class Phergie_Plugin_Cron extends Phergie_Plugin_Abstract
 
             echo 'DEBUG(Cron): Callback ', $callbackString,
                 ' scheduled for ', date('H:i:s', $scheduled), ',',
-                ' executed at ', date('H:i:s', $now), PHP_EOL;
+                ' executed at ', date('H:i:s', $time), PHP_EOL;
 
             if ($callback['repeat']) {
                 $callback['scheduled'] = $time + $callback['delay'];


### PR DESCRIPTION
Fixes issue #96 - Bug in Cron.php line 133 where undefined var $now was being referenced, replaced with $time 
