### PR TITLE
Twitter plugin has problems since Snowflake upgrade

### DIFF
--- a/Phergie/Plugin/Twitter/twitter.class.php
+++ b/Phergie/Plugin/Twitter/twitter.class.php
@@ -39,27 +39,27 @@ class Twitter
      * Do not specify user/password in URL
      */
     protected $baseUrl = 'http://twitter.com/';
-    
+
     /**
      * Full base URL (includes user/pass)
      *
      * (created in Init)
      */
     protected $baseUrlFull = null;
-    
+
     /**
      * Twitter API user
      */
     protected $user;
-    
+
     /**
      * Twitter API password
      */
     protected $pass;
-    
+
     /**
      * Constructor; sets up configuration.
-     * 
+     *
      * @param string $user Twitter user name; null for limited read-only access
      * @param string $pass Twitter password; null for limited read-only access
      */
@@ -124,7 +124,7 @@ class Twitter
         }
         return $tweet;
     }
-    
+
     /**
      * fetches mentions for a user
      *
@@ -136,7 +136,7 @@ class Twitter
     public function getMentions($sinceId=null, $count=20) {
         return json_decode(file_get_contents($this->getUrlMentions($sinceId, $count)));
     }
-    
+
     /**
      * Fetches followers for a user
      *
@@ -148,7 +148,7 @@ class Twitter
     {
         return json_decode(file_get_contents($this->getUrlFollowers($cursor)));
     }
-    
+
     /**
      * Follow a userid
      *
@@ -177,7 +177,7 @@ class Twitter
         $response = json_decode($response);
         return $response;
     }
-    
+
     /**
      * fetches DMs for a user
      *
@@ -193,7 +193,7 @@ class Twitter
             file_get_contents($this->getUrlDMs($sinceId, $count, $page))
         );
     }
-    
+
     /**
      * Send DM
      *
@@ -260,7 +260,7 @@ class Twitter
         $response = json_decode($response);
         return $response;
     }
-    
+
     /**
      * Returns the base API URL
      *
@@ -270,7 +270,7 @@ class Twitter
     {
         return $this->baseUrlFull;
     }
-    
+
     /**
      * Returns the status URL
      *
@@ -283,7 +283,7 @@ class Twitter
         return $this->getUrlApi() . 'statuses/show/'
             . urlencode($num) .'.json';
     }
-    
+
     /**
      * Returns the user timeline URL
      *
@@ -296,7 +296,7 @@ class Twitter
         return $this->getUrlApi() . 'statuses/user_timeline/'
                 . urlencode($user) . '.json';
     }
-    
+
     /**
      * Returns the tweet posting URL
      *
@@ -306,10 +306,10 @@ class Twitter
     {
         return $this->getUrlApi() . 'statuses/update.json';
     }
-    
+
     /**
      * Output URL: status
-     * 
+     *
      * @param Stdclass $tweet TODO desc
      *
      * @return TODO desc
@@ -317,9 +317,9 @@ class Twitter
     public function getUrlOutputStatus(StdClass $tweet)
     {
         return $this->baseUrl . urlencode($tweet->user->screen_name)
-            . '/statuses/' . urlencode($tweet->id);
+            . '/statuses/' . urlencode($tweet->id_str);
     }
-    
+
     /**
      * Return mentions URL
      *
@@ -337,7 +337,7 @@ class Twitter
         }
         return $url;
     }
-    
+
     /**
      * Returns the followers URL
      *
@@ -350,7 +350,7 @@ class Twitter
         return $this->baseUrlFull . 'statuses/followers.json?cursor='
             . ((int)$cursor);
     }
-    
+
     /**
      * Returns the follow-user URL
      *
@@ -363,7 +363,7 @@ class Twitter
         return $this->baseUrlFull . 'friendships/create/'
             . ((int) $userid) . '.json';
     }
-    
+
     /**
      * Returns the get DMs URL
      *


### PR DESCRIPTION
Twitter IDs are now too long to be represented by a PHP `int` type, and end up as floating-point numbers. They should use the `id_str` argument rather than `id`.
