### PR TITLE
Untitled

### DIFF
--- a/Phergie/Plugin/Remind.php
+++ b/Phergie/Plugin/Remind.php
@@ -226,7 +226,7 @@ class Phergie_Plugin_Remind extends Phergie_Plugin_Abstract
      */
     protected function deliverReminders($channel, $nick)
     {
-        if ($channel[0] != '#') {
+        if (!$this->getEvent()->isInChannel()) {
             // private message, not a channel, so don't check
             return;
         }


### PR DESCRIPTION
Use the provided isInChannel() method to avoid checking for reminders in a private message, rather than using a single hardcoded # to detect a channel name.
