### PR TITLE
Make better use of assertInternalType

### DIFF
--- a/Tests/Phergie/Connection/HandlerTest.php
+++ b/Tests/Phergie/Connection/HandlerTest.php
@@ -181,7 +181,7 @@ class Phergie_Connection_HandlerTest extends Phergie_TestCase
 
         $this->connections->addConnection($connection);
         $connections = $this->connections->getConnections($hostmaskString);
-        $this->assertTrue(is_array($connections));
+        $this->assertInternalType('array', $connections);
         $this->assertSame(1, count($connections));
         $this->assertArrayHasKey($hostmaskString, $connections);
         $this->assertSame($connection, $connections[$hostmaskString]);
@@ -209,7 +209,7 @@ class Phergie_Connection_HandlerTest extends Phergie_TestCase
             $this->connections->addConnection($connections[$index]);
         }
         $returned = $this->connections->getConnections($hostmaskStrings);
-        $this->assertTrue(is_array($returned));
+        $this->assertInternalType('array', $returned);
         $this->assertEquals(2, count($returned));
         foreach ($hostmaskStrings as $index => $hostmaskString) {
             $this->assertArrayHasKey($hostmaskString, $returned);

--- a/Tests/Phergie/Plugin/HandlerTest.php
+++ b/Tests/Phergie/Plugin/HandlerTest.php
@@ -197,8 +197,9 @@ class Phergie_Plugin_HandlerTest extends PHPUnit_Framework_TestCase
             'Handler does not implement Countable'
         );
 
-        $this->assertTrue(
-            is_int(count($this->handler)),
+        $this->assertInternalType(
+            'int',
+            count($this->handler),
             'count() must return an integer'
         );
     }


### PR DESCRIPTION
Drop the combination assertTrue with is_array or is_int
in favor of assertInternalType

This patch is based on a commit from pull request #116 that can be found on
https://github.com/pinpin/phergie/commit/f741f427524d586a07a06aaf48fea9d4fa2620e7
