### PR TITLE
Reset ping check if we get any event at all.

### DIFF
--- a/Phergie/Plugin/Ping.php
+++ b/Phergie/Plugin/Ping.php
@@ -58,22 +58,13 @@ class Phergie_Plugin_Ping extends Phergie_Plugin_Abstract
 
     /**
      * Updates the timestamp since the last received event when a new event
-     * arrives.
+     * arrives. Also, clears the ping time as well.
      *
      * @return void
      */
     public function preEvent()
     {
         $this->lastEvent = time();
-    }
-
-    /**
-     * Clears the ping time if a reply is received.
-     *
-     * @return void
-     */
-    public function onPingResponse()
-    {
         $this->lastPing = null;
     }
 


### PR DESCRIPTION
Fixes issue elazar/phergie#146.

The Ping plugin expected to reset the ping check timer when onPingResponse() was invoked, which never seems to actually happen. Simply resetting the ping check on any event generated using preEvent() seems to be adequate. However, we should really only reset the ping check on an event that corresponds to receiving data from the server as that's the whole point of the check in the first place, so perhaps a future enhancement would be to only reset the ping check if the event that triggers preEvent() is a Phergie_Event_Response.
