### PR TITLE
Use a separate warning for Windows, which doesn't have chmod

### DIFF
--- a/Tests/Phergie/ConfigTest.php
+++ b/Tests/Phergie/ConfigTest.php
@@ -162,6 +162,9 @@ class Phergie_ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testReadThrowsExceptionForUnreadableFile()
     {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $this->markTestSkipped('chmod() call to make file unreadable useless on windows');
+        }
         $file = $this->createTempFile();
         if (!chmod($file, 0000)) {
             $this->markTestSkipped('chmod() call to make file unreadable failed');


### PR DESCRIPTION
Changes after being extracted from the original patch: replaced tabs by spaces

This patch is based on a commit from pull request #116 that can be found on
https://github.com/pinpin/phergie/commit/f741f427524d586a07a06aaf48fea9d4fa2620e7
