### PR TITLE
Support message.aliases in Phergie_Plugin_Message

### DIFF
--- a/Phergie/Plugin/Message.php
+++ b/Phergie/Plugin/Message.php
@@ -44,7 +44,10 @@ class Phergie_Plugin_Message extends Phergie_Plugin_Abstract
     {
         $event = $this->getEvent();
 
-        $self = preg_quote($this->connection->getNick());
+        $me = preg_quote($this->connection->getNick());
+        $aliases = $this->getConfig('message.aliases');
+        $self = '(?:' . implode('|',
+            array_merge((array) $me, (array) $aliases)) . ')';
 
         $targetPattern = <<<REGEX
         {^
@@ -67,7 +70,10 @@ REGEX;
         $event = $this->getEvent();
 
         $prefix = preg_quote($this->getConfig('command.prefix'));
-        $self = preg_quote($this->connection->getNick());
+        $me = preg_quote($this->connection->getNick());
+        $aliases = $this->getConfig('message.aliases');
+        $self = '(?:' . implode('|',
+            array_merge((array) $me, (array) $aliases)) . ')';
         $message = $event->getText();
 
         // $prefixPattern matches : Phergie, do command <parameters>

--- a/Tests/Phergie/Plugin/MessageTest.php
+++ b/Tests/Phergie/Plugin/MessageTest.php
@@ -59,4 +59,18 @@ class Phergie_Plugin_MessageTest extends Phergie_Plugin_TestCase
         $this->initializeMessageEvent($this->connection->getNick() . ', hello');
         $this->assertTrue($this->plugin->isTargetedMessage());
     }
+
+    public function testGetMessageWithAlias()
+    {
+        $this->setConfig('message.aliases', array('alias'));
+        $this->initializeMessageEvent('alias, hello');
+        $this->assertEquals('hello', $this->plugin->getMessage());
+    }
+
+    public function testIsTargetedMessageWithAlias()
+    {
+        $this->setConfig('message.aliases', array('alias'));
+        $this->initializeMessageEvent('alias, hello');
+        $this->assertTrue($this->plugin->isTargetedMessage());
+    }
 }


### PR DESCRIPTION
This pull request adds a pair of minimal positive test cases for the current Phergie_Plugin_Message, then adds two new tests for new functionality, specifying alternate "aliases" for the bot, set in configuration message.aliases.
