### PR TITLE
Properly handling passwords when provided in the autojoin list.

### DIFF
--- a/Phergie/Plugin/AutoJoin.php
+++ b/Phergie/Plugin/AutoJoin.php
@@ -62,7 +62,7 @@ class Phergie_Plugin_AutoJoin extends Phergie_Plugin_Abstract
                         $channels = implode(',', $channels);
                     }
                 } elseif (strpos($channels, ' ') !== false) {
-                        list($channels, $keys) = explode(' ', $channels);
+                    list($channels, $keys) = explode(' ', $channels);
                 }
 
                 $this->doJoin($channels, $keys);


### PR DESCRIPTION
Attempting to join a private channel via the autojoin plugin was broken, since it was not passing the keys as a separate parameter to doJoin.
