### PR TITLE
Fail php plugin if db is not loaded

### DIFF
--- a/Phergie/Plugin/Php.php
+++ b/Phergie/Plugin/Php.php
@@ -54,7 +54,11 @@ class Phergie_Plugin_Php extends Phergie_Plugin_Abstract
 
         $this->getPluginHandler()->getPlugin('Command');
 
-        $this->source = new Phergie_Plugin_Php_Source_Local;
+        try {
+            $this->source = new Phergie_Plugin_Php_Source_Local;
+        } catch (Phergie_Plugin_Source_Local_Exception $e) {
+            $this->fail($e->getMessage());
+        }
     }
 
     /**

--- a/Phergie/Plugin/Php/Exception.php
+++ b/Phergie/Plugin/Php/Exception.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Phergie
+ *
+ * PHP version 5
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.
+ * It is also available through the world-wide-web at this URL:
+ * http://phergie.org/license
+ *
+ * @category  Phergie
+ * @package   Phergie
+ * @author    Phergie Development Team <team@phergie.org>
+ * @copyright 2008-2011 Phergie Development Team (http://phergie.org)
+ * @license   http://phergie.org/license New BSD License
+ * @link      http://pear.phergie.org/package/Phergie
+ */
+
+/**
+ * Exception class
+ *
+ * @category Phergie
+ * @package  Phergie
+ * @author   Phergie Development Team <team@phergie.org>
+ * @license  http://phergie.org/license New BSD License
+ * @link     http://pear.phergie.org/package/Phergie
+ */
+class Phergie_Plugin_Php_Exception extends Phergie_Plugin_Exception
+{
+}

--- a/Phergie/Plugin/Php/Source/Exception.php
+++ b/Phergie/Plugin/Php/Source/Exception.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Phergie
+ *
+ * PHP version 5
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.
+ * It is also available through the world-wide-web at this URL:
+ * http://phergie.org/license
+ *
+ * @category  Phergie
+ * @package   Phergie
+ * @author    Phergie Development Team <team@phergie.org>
+ * @copyright 2008-2011 Phergie Development Team (http://phergie.org)
+ * @license   http://phergie.org/license New BSD License
+ * @link      http://pear.phergie.org/package/Phergie
+ */
+
+/**
+ * Exception class
+ *
+ * @category Phergie
+ * @package  Phergie
+ * @author   Phergie Development Team <team@phergie.org>
+ * @license  http://phergie.org/license New BSD License
+ * @link     http://pear.phergie.org/package/Phergie
+ */
+class Phergie_Plugin_Php_Source_Exception extends Phergie_Plugin_Php_Exception
+{
+}

--- a/Phergie/Plugin/Php/Source/Local.php
+++ b/Phergie/Plugin/Php/Source/Local.php
@@ -65,7 +65,7 @@ class Phergie_Plugin_Php_Source_Local implements Phergie_Plugin_Php_Source
             // @todo Modify this to be rethrown as an appropriate 
             //       Phergie_Plugin_Exception and handled in Phergie_Plugin_Php
         } catch (PDOException $e) {
-            echo 'PDO failure: '.$e->getMessage();
+            throw new Phergie_Plugin_Php_Source_Exception('PDO failure: ' . $e->getMessage());
         } 
     }
 
@@ -222,7 +222,7 @@ class Phergie_Plugin_Php_Source_Local implements Phergie_Plugin_Php_Source
                         array(':name' => $name, ':description' => $line)
                     );
                 }
-                
+
                 // Commit the changes to the database
                 $this->database->commit();
             }


### PR DESCRIPTION
Details in commits, so please read them.

This is a quick fix to solve a fatal error, give feedback when necessary.

Todo: reproduce the error in master, its know to be reproduced in 2.0.4.
