### PR TITLE
Tracking joins in UserInfo

### DIFF
--- a/Phergie/Plugin/UserInfo.php
+++ b/Phergie/Plugin/UserInfo.php
@@ -113,7 +113,7 @@ class Phergie_Plugin_UserInfo extends Phergie_Plugin_Abstract
      */
     public function onJoin()
     {
-        $chan = trim(strtolower($this->event->getArgument(0)));
+        $chan = ltrim(trim(strtolower($this->event->getArgument(0))), ":");
         $nick = trim($this->event->getNick());
 
         $this->store[$chan][$nick] = self::REGULAR;


### PR DESCRIPTION
UserInfo doesn't track users on join. That explains the bug: http://pastebin.com/jeL4BC0T (first character of channel name is doublecolon).

(used ltrim instead of str_replace according to avdg advice)
