### PR TITLE
BUGFIX: mt_rand issues E_WARNING (since PHP5.3) if max is lower than min (which is hardcoded to 1)

### DIFF
--- a/Phergie/Plugin/Dice.php
+++ b/Phergie/Plugin/Dice.php
@@ -60,7 +60,9 @@ class Phergie_Plugin_Dice extends Phergie_Plugin_Abstract
             list (, $num, $die, $mod, $rest) = $matches;
             $roll = 0;
             for ($i = 0; $i < $num; $i++) {
-                $roll += mt_rand(1, $die);
+                if ($die >= 1) { //BUGFIX: mt_rand issues E_WARNING (since PHP5.3) if max is lower than min (which is hardcoded to 1)
+                    $roll += mt_rand(1, $die);
+                }
             }
             $roll = min($roll, $num * $die);
             if (!empty($mod)) {


### PR DESCRIPTION
Before fix:
dana:Tests remi$ phpunit Phergie/Plugin/DiceTest.php 
PHPUnit 3.5.15 by Sebastian Bergmann.

...E..

Time: 0 seconds, Memory: 9.25Mb

There was 1 error:

1) Phergie_Plugin_DiceTest::testSimpleRolls
mt_rand(): max(0) is smaller than min(1)

/Users/remi/Code/phergie/Phergie/Plugin/Dice.php:63
/Users/remi/Code/phergie/Tests/Phergie/Plugin/DiceTest.php:90
/Users/remi/Code/phergie/Tests/Phergie/Plugin/DiceTest.php:104
/Users/remi/Code/phergie/Tests/Phergie/Plugin/DiceTest.php:140

FAILURES!

TestCase:
dana:phergie remi$ php -r "echo mt_rand(1,0);"
PHP Warning:  mt_rand(): max(0) is smaller than min(1) in Command line code on line 1
PHP Stack trace:
PHP   1. {main}() Command line code:0
PHP   2. mt_rand() Command line code:1
dana:phergie remi$ php -v
PHP 5.3.8 with Suhosin-Patch (cli) (built: Nov 15 2011 15:33:15) 
Copyright (c) 1997-2011 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2011 Zend Technologies
    with Xdebug v2.1.2, Copyright (c) 2002-2011, by Derick Rethans

After fix:
dana:Tests remi$ phpunit Phergie/Plugin/DiceTest.php 
PHPUnit 3.5.15 by Sebastian Bergmann.

......

Time: 0 seconds, Memory: 9.25Mb

OK (6 tests, 41 assertions)
