### PR TITLE
fixed Ctcp plugin causing infinite loop when bot sends ctcp version to itself

### DIFF
--- a/Phergie/Plugin/Ctcp.php
+++ b/Phergie/Plugin/Ctcp.php
@@ -51,6 +51,9 @@ class Phergie_Plugin_Ctcp extends Phergie_Plugin_Abstract
      */
     public function onVersion()
     {
+        if ($this->getEvent()->getArguments()) {
+            return;
+        }
         $source = $this->getEvent()->getSource();
         $msg = 'Phergie ' . Phergie_Bot::VERSION . ' (http://phergie.org)';
         $this->doVersion($source, $msg);


### PR DESCRIPTION
Since CTCP VERSION doesn't expect additional arguments other than the nick, the fix causes Ctcp to abort if there are any arguments (the version msg string).
