### PR TITLE
Fix #169: getMockEvent has an unused parameter $type

### DIFF
--- a/Tests/Phergie/Plugin/DiceTest.php
+++ b/Tests/Phergie/Plugin/DiceTest.php
@@ -55,7 +55,7 @@ class Phergie_Plugin_DiceTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => 'roll ' . $roll
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
     }
 

--- a/Tests/Phergie/Plugin/KarmaTest.php
+++ b/Tests/Phergie/Plugin/KarmaTest.php
@@ -81,7 +81,7 @@ class Phergie_Plugin_KarmaTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => 'karma ' . $term
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
         return $event;
     }
@@ -186,7 +186,7 @@ class Phergie_Plugin_KarmaTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => $term . $operation
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
         $this->plugin->onPrivmsg();
         $event = $this->initiateKarmaEvent($term);
@@ -310,7 +310,7 @@ class Phergie_Plugin_KarmaTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => $term1 . ' ' . $operator . ' ' . $term2
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
 
         // Test lack of a response for terms with fixed karma ratings

--- a/Tests/Phergie/Plugin/MessageTest.php
+++ b/Tests/Phergie/Plugin/MessageTest.php
@@ -46,7 +46,7 @@ class Phergie_Plugin_MessageTest extends Phergie_Plugin_TestCase
             'receiver' => $source,
             'text' => $message
         );
-        $event = $this->getMockEvent('privmsg', $args, $this->nick, $source);
+        $event = $this->getMockEvent($args, $this->nick, $source);
         $this->plugin->setEvent($event);
     }
 

--- a/Tests/Phergie/Plugin/PongTest.php
+++ b/Tests/Phergie/Plugin/PongTest.php
@@ -38,7 +38,7 @@ class Phergie_Plugin_PongTest extends Phergie_Plugin_TestCase
     public function testPong()
     {
         $expected = 'irc.freenode.net';
-        $event = $this->getMockEvent('ping', array($expected));
+        $event = $this->getMockEvent(array($expected));
         $this->plugin->setEvent($event);
         $this->assertEmitsEvent('pong', array($expected));
         $this->plugin->onPing();

--- a/Tests/Phergie/Plugin/SpellCheckTest.php
+++ b/Tests/Phergie/Plugin/SpellCheckTest.php
@@ -105,7 +105,7 @@ class Phergie_Plugin_SpellCheckTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => 'spell ' . $word
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
     }
 

--- a/Tests/Phergie/Plugin/TerryChayTest.php
+++ b/Tests/Phergie/Plugin/TerryChayTest.php
@@ -107,7 +107,7 @@ class Phergie_Plugin_TerryChayTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => $trigger
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
         $this->assertEmitsEvent(
             'privmsg', array($this->source, 'Fact: ' . $this->chayism)
@@ -127,7 +127,7 @@ class Phergie_Plugin_TerryChayTest extends Phergie_Plugin_TestCase
             'receiver' => $this->source,
             'text' => 'foo bar baz'
         );
-        $event = $this->getMockEvent('privmsg', $args);
+        $event = $this->getMockEvent($args);
         $this->plugin->setEvent($event);
         $this->assertDoesNotEmitEvent(
             'privmsg', array($this->source, 'Fact: ' . $this->chayism)

--- a/Tests/Phergie/Plugin/WeatherTest.php
+++ b/Tests/Phergie/Plugin/WeatherTest.php
@@ -175,7 +175,7 @@ class Phergie_Plugin_WeatherTest extends Phergie_Plugin_TestCase
     {
         $config = $this->setUpWeatherResponse($test);
 
-        $event = $this->getMockEvent('weathercommand');
+        $event = $this->getMockEvent();
         $this->plugin->setEvent($event);
 
         $this->assertEmitsEvent(

--- a/Tests/Phergie/TestCase.php
+++ b/Tests/Phergie/TestCase.php
@@ -240,7 +240,7 @@ abstract class Phergie_TestCase extends PHPUnit_Framework_TestCase
      *
      * @return Phergie_Event_Request
      */
-    protected function getMockEvent($type, array $args = array(),
+    protected function getMockEvent(array $args = array(),
         $nick = null, $source = null
     ) {
         $methods = array('getNick', 'getSource');


### PR DESCRIPTION
Removed the parameter in the signature and all calls.
