### PR TITLE
Cache URL responses correctly.

### DIFF
--- a/Phergie/Plugin/Url.php
+++ b/Phergie/Plugin/Url.php
@@ -360,7 +360,7 @@ class Phergie_Plugin_Url extends Phergie_Plugin_Abstract
          * cache; if expire is disabled, check if the URL is listed
          */
         if ($expire > 0
-            && isset($cache['url'][$source], $cache['shortened'][$source])
+            && isset($cache['url'][$source][$url], $cache['shortened'][$source][$shortenedUrl])
         ) {
             unset($cache, $url, $shortenedUrl, $expire);
             return true;
@@ -382,6 +382,9 @@ class Phergie_Plugin_Url extends Phergie_Plugin_Abstract
     {
         $cache = array();
         $source = $this->getEvent()->getSource();
+
+        $cache['urlCache'] = $this->cache->fetch('urlCache');
+        $cache['shortCache'] = $this->cache->fetch('shortCache');
 
         /**
          * Transform URL (+shortened) into HEX CRC32 checksum to prevent


### PR DESCRIPTION
I discovered that my links were not being replaced to me by Phergie. I thought it was a problem with my .io domain (http://sculpin.io) so I checked others (http://nelm.io, http://igor.io) and those failed as well. However, upon further checking and testing, I found that other URLs were not coming up either... turns out that it was more of a cache issue than anything. As long as anything was in cache, all other requests would show up as being "in cache" and ignored. As soon as the most recently added cache item fell out of cache a new URL would be able to be shown but until that cache expired nothing else could be added.

This looks to fix the cache issue. I've tested it out in one of my channels and it will take all URLs the first time and will not display them again until the cache expires.
