### PR TITLE
Add HTTP 407 response for proxy authentication.

### DIFF
--- a/Phergie/Plugin/Http/Response.php
+++ b/Phergie/Plugin/Http/Response.php
@@ -61,6 +61,7 @@ class Phergie_Plugin_Http_Response
         404 => 'Not Found',
         405 => 'Method Not Allowed',
         406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
         408 => 'Request Timeout',
         410 => 'Gone',
         413 => 'Request Entity Too Large',


### PR DESCRIPTION
It took me a little time to figure out why I was getting 'Unknown HTTP Status', and eventually I found I was getting a 407 response, which Phergie doesn't account for. Behind proxies, a 407 is returned, so it would be nice if Phergie gave the appropriate error.
