### PR TITLE
Adding trivia plugin to Phergie

### DIFF
--- a/Phergie/Plugin/Trivia.php
+++ b/Phergie/Plugin/Trivia.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Play some trivia, it's good for you!
+ *
+ * Trivia questions database were sourced from : http://www.irc-wiki.org/Category:Trivia_questions
+ *
+ * @category Trivia
+ * @package  Phergie_Plugin_Trivia
+ * @author   David Walker <dwalker@symplicity.com>
+ * @license  GPLv2
+ * @link     http://github.com/Symplicity/phergie
+ * @link     http://symplicity.com
+ */
+
+/**
+ * Instructions
+ *
+ * Enable the plugin in your config file.
+ *
+ * To build the questions db, run db.php in the Trivia folder.
+ *
+ * To start a game of trivia, all you need to to is type: trivia
+ * Trivia will then ask questions, and await answers.  Answers are given by a line starting with '='
+ *
+ * Exmaple:
+ * Question 1 : Animals
+ * What has 4 legs and goes bark?
+ * =dog
+ * CORRECT
+ *
+ * At any point, an operator may stop a game of trivia with the command: endtrivia
+ *
+ * Voting allows players to judge, and remove questions from the DB if they are poor questions.
+ */
+
+class Phergie_Plugin_Trivia extends Phergie_Plugin_Abstract {
+	const ROUND_NONE = 1;
+	const ROUND_ANNOUNCE = 2;
+	const ROUND_RUNNING = 3;
+	const ROUND_VOTING = 4;
+	const ROUND_ENDED = 5;
+
+	private $trivia;
+	private $db;
+	private $rounds;
+	private $question_time;
+	private $round_delay;
+	private $voting_period;
+	private $vote_threashold;
+	private $display_answer;
+
+	private function joinQuoted($chr, $in) {
+		$out = array();
+		if (!is_array($in)) {
+			$in = array($in);
+		}
+		foreach ($in as $k => $v) {
+			if ($v != '' || $v === 0) {
+				$out[$k] = "'$v'";
+			}
+		}
+		return join($chr, $out);
+	}
+
+	public function onLoad() {
+		$this->trivia = array();
+		$this->db = new PDO('sqlite:' . __DIR__ . '/Trivia/trivia.db');
+
+		$plugins = $this->getPluginHandler();
+		$plugins->getPlugin('Command');
+		$plugins->getPlugin('UserInfo');
+
+		$this->rounds = $this->config['trivia.rounds'] ?: 10;
+		$this->question_time = $this->config['trivia.question_time'] ?: 60;
+		$this->round_delay = $this->config['trivia.round_delay'] ?: 5;
+		$this->voting_period = $this->config['trivia.voting_period'] ?: 15;
+		$this->vote_threashold = $this->config['trivia.vote_threashold'] ?: -5;
+		$this->display_answer = $this->config['trivia.display_answer'] ?: false;
+	}
+
+	public function onCommandTrivia() {
+		$nick = trim($this->getEvent()->getNick());
+		$chan = trim($this->getEvent()->getSource());
+
+		if (($this->event->isInChannel() && $this->plugins->userInfo->isOp($nick, $chan))) {
+			if (empty($this->trivia[$chan])) {
+				$this->trivia[$chan] = array(
+					'chan' => $chan,
+					'round_status' => ROUND_NONE,
+					'announced' => null,
+					'round_started' => null,
+					'mid_round' => false,
+					'round' => 1,
+					'scores' => array(),
+					'question' => array(),
+					'seen_questions' => array(),
+					'user_answers' => array(),
+				);
+
+				$this->doPrivmsg($chan, "4Welcome to Trivia!");
+				$this->doPrivmsg($chan, "4May the odds never be in your favor!");
+			}
+		}
+	}
+
+	public function onCommandStoptrivia() {
+		$this->onCommandEndtrivia();
+	}
+
+	public function onCommandEndtrivia() {
+		$nick = trim($this->getEvent()->getNick());
+		$chan = trim($this->getEvent()->getSource());
+
+		if ($this->event->isInChannel() && $this->plugins->userInfo->isOp($nick, $chan)) {
+			if (!empty($this->trivia[$chan])) {
+				$this->doPrivmsg($chan, "4OP Stopped Trivia, probably because you are all sad losers!");
+				unset($this->trivia[$chan]);
+			}
+		}
+	}
+
+	public function onPrivmsg() {
+		$msg = $this->plugins->message->getMessage();
+
+		if ($msg[0] == '=') {
+			$answer = strtolower(substr($msg, 1));
+			$answer = preg_replace('/\s+/', ' ', $answer);
+			$this->onAnswer($answer);
+		}
+	}
+
+	public function onAnswer($user_answer) {
+		$chan = trim($this->getEvent()->getSource());
+		$nick = trim($this->getEvent()->getNick());
+
+		if (empty($this->trivia[$chan])) {
+			return;
+		}
+
+		$game =& $this->trivia[$chan];
+
+		if ($game['user_answers'][$nick] >= 3) {
+			$this->doPrivmsg($nick, "4$nick, you can only answer 3 times per question.");
+			return;
+		}
+
+		$game['user_answers'][$nick]++;
+
+		if ($game['round_status'] == ROUND_RUNNING) {
+			if ($regex = $game['question']['regex']) {
+				if (preg_match('/' . $regex . '/i', $user_answer, $matches)) {
+					$this->endRound($game, $nick);
+				}
+			} else {
+				$answer = $game['question']['answer'];
+
+				if (preg_match('/#([^#]+?)#/', $answer, $matches)) {
+					$answer = $matches[1];
+				}
+
+				if (stripos($user_answer, $answer) !== false) {
+					$this->endRound($game, $nick);
+				}
+			}
+		}
+	}
+
+	protected function startRound(&$game) {
+		$game['round_status'] = ROUND_ANNOUNCE;
+		$game['announced'] = time();
+		unset($game['question']);
+
+		$where = '';
+		if (count($game['seen_questions'])) {
+			$where = "where id not in (" . $this->joinQuoted(',', $game['seen_questions']) . ")";
+		}
+
+		$get = $this->db->query("SELECT * FROM trivia $where ORDER BY RANDOM() LIMIT 1");
+		$game['question'] = $get->fetch(PDO::FETCH_ASSOC);
+		$game['seen_questions'][] = $game['question']['id'];
+
+		$this->doPrivmsg($game['chan'], "12Round: 10{$game['round']}");
+		$vote = $this->db->query("SELECT sum(vote) as count FROM voting where trivia_id = '{$game['question']['id']}'");
+		$vote = $vote->fetch(PDO::FETCH_ASSOC);
+		$vote = $vote['count'] ?: "0";
+		$this->doPrivmsg($game['chan'], "- 3Category: {$game['question']['category']} (Vote: $vote)");
+	}
+
+	protected function announceQuestion(&$game) {
+		$game['round_status'] = ROUND_RUNNING;
+		$game['round_started'] = time();
+		$this->doPrivmsg($game['chan'], "- 3Question: {$game['question']['question']}");
+	}
+
+	protected function getScores(&$game) {
+		$scores = array();
+
+		if (count($game['scores'])) {
+			arsort($game['scores']);
+			foreach ($game['scores'] as $nick => $score) {
+				$scores[] = '[ ' . $nick . ' - ' . $score . ' ]';
+			}
+		}
+
+		return $scores;
+	}
+
+	protected function getLeaders(&$game) {
+		$high_score = 0;
+		$leaders = array();
+
+		if (count($game['scores'])) {
+			foreach ($game['scores'] as $nick => $score) {
+				if ($high_score < $score) {
+					$leaders = array();
+					$leaders[] = $nick;
+					$high_score = $score;
+				} elseif ($score == $high_score) {
+					$leaders[] = $nick;
+				}
+			}
+		}
+
+		return $leaders;
+	}
+
+	protected function endRound(&$game, $winner = null) {
+		$game['round_status'] = ROUND_VOTING;
+		$game['round_ended'] = time();
+		$game['mid_round'] = false;
+		$game['user_answers'] = array();
+		usleep(700000);
+
+		$this->doPrivmsg($game['chan'], "3Round {$game['round']} has ended.");
+		$game['round']++;
+
+		if (is_null($winner)) {
+			$this->doPrivmsg($game['chan'], "4Nobody won this round!  You are all losers to me.");
+			if ($this->display_answer) {
+				$this->doPrivmsg($game['chan'], "7The answer was: {$game['question']['answer']}.");
+			}
+		} else {
+			$this->doPrivmsg($game['chan'], "4$winner won this round!");
+			$game['scores'][$winner]++;
+		}
+
+		$this->doPrivmsg($game['chan'], "7Current Scores:");
+
+		$scores = $this->getScores($game);
+
+		if (count($scores)) {
+			$this->doPrivmsg($game['chan'], "7".join(',', $scores));
+		} else {
+			$this->doPrivmsg($game['chan'], "7Nobody has scored yet");
+		}
+
+		$this->doPrivmsg($game['chan'], "4Voting period on the question is open.");
+	}
+
+	public function doVote($vote = 0) {
+		$nick = trim($this->getEvent()->getNick());
+		$chan = trim($this->getEvent()->getSource());
+
+		if (empty($this->trivia[$chan])) {
+			return;
+		}
+
+		$game =& $this->trivia[$chan];
+
+		if ($game['round_status'] == ROUND_VOTING) {
+			$this->db->query("REPLACE INTO voting (trivia_id, nick, vote) VALUES ('{$game['question']['id']}', '$nick', $vote)");
+			$vote = $this->db->query("SELECT sum(vote) as count FROM voting where trivia_id = '{$game['question']['id']}'");
+			$vote = $vote->fetch(PDO::FETCH_ASSOC);
+			if ($vote <= $this->vote_threashold) {
+				$this->db->query("DELETE FROM voting WHERE id = '{$game['question']['id']}'");
+			}
+		}
+	}
+
+	public function onCommandUpvote() {
+		$this->doVote(1);
+	}
+
+	public function onCommandDownvote() {
+		$this->doVote(-1);
+	}
+
+	public function onTick() {
+		foreach ($this->trivia as &$game) {
+			switch ($game['round_status']) {
+			case ROUND_NONE:
+				$this->startRound($game);
+				break;
+			case ROUND_ANNOUNCE:
+				if (($game['announced'] + $this->round_delay) < time()) {
+					$this->announceQuestion($game);
+				}
+				break;
+			case ROUND_RUNNING:
+				if (!$game['mid_round'] && ($game['round_started'] + (($this->round_delay + $this->question_time)/2)) < time()) {
+					$game['mid_round'] = true;
+					$this->doPrivmsg($game['chan'], "13Nobody has answered the question, ".($this->question_time/2)." seconds remain.");
+					$this->doPrivmsg($game['chan'], "- 3Question: {$game['question']['question']}");
+				}
+
+				if (($game['round_started'] + ($this->round_delay + $this->question_time)) < time()) {
+					$this->endRound($game);
+				}
+				break;
+			case ROUND_VOTING:
+				if (($game['round_ended'] + $this->voting_period) < time()) {
+					$game['round_status'] = ROUND_ENDED;
+				}
+				break;
+			case ROUND_ENDED:
+				if ($game['round'] > $this->rounds) {
+					$leaders = $this->getLeaders($game);
+					if ($num_leaders = count($leaders)) {
+						$winner_txt = $num_leaders > 1 ? 'winners' : 'winner';
+						$isare = $num_leaders > 1 ? 'are' : 'is';
+						$this->doPrivmsg($game['chan'], "4Game Over!  Your $winner_txt $isare: " . join(', ', $leaders));
+					} else {
+						$this->doPrivmsg($game['chan'], "4Game Over!  Y'all are a sack of losers");
+					}
+
+					$scores = $this->getScores($game);
+					if (count($scores)) {
+						$this->doPrivmsg($game['chan'], "7Final Scores:");
+						$this->doPrivmsg($game['chan'], "7".join(',', $scores));
+					}
+
+					unset($this->trivia[$game['chan']]);
+				} else {
+					if (($game['round_ended'] + $this->round_delay) < time()) {
+						$game['round_status'] = ROUND_NONE;
+					}
+				}
+				break;
+			}
+		}
+	}
+}

--- a/Phergie/Plugin/Trivia/db.php
+++ b/Phergie/Plugin/Trivia/db.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Play some trivia, it's good for you!
+ *
+ * Trivia questions database were sourced from : http://www.irc-wiki.org/Category:Trivia_questions
+ *
+ * @category Trivia
+ * @package  Phergie_Plugin_Trivia
+ * @author   David Walker <dwalker@symplicity.com>
+ * @license  GPLv2
+ * @link     http://github.com/Symplicity/phergie
+ * @link     http://symplicity.com
+ */
+
+$dbfile = './trivia.db';
+if (file_exists($dbfile)) {
+	unlink($dbfile);
+}
+
+$db = new PDO('sqlite:' . $dbfile);
+$db->exec('DROP TABLE trivia');
+$db->exec('CREATE TABLE trivia (id INTEGER PRIMARY KEY AUTOINCREMENT, category VARCHAR(255), question VARCHAR(255), answer VARCHAR(255), regex VARCHAR(255))');
+$db->exec('CREATE TABLE voting (trivia_id INTEGER, nick VARCHAR(255), vote INTEGER, PRIMARY KEY (trivia_id, nick))');
+
+$insert = $db->prepare('INSERT INTO trivia (id, category, question, answer, regex) VALUES (NULL, :category, :question, :answer, :regex)');
+
+$question_files = array(
+	'questions.txt',
+);
+
+$db->beginTransaction();
+
+foreach ($question_files as $qf) {
+	$fh = fopen($qf, 'r');
+
+	$records = array();
+	$counter = 0;
+	do {
+		$line = trim(fgets($fh));
+
+		if ($line) {
+			$records[$counter][] = $line;
+		} else {
+			$counter++;
+		}
+	} while (!feof($fh));
+
+	foreach ($records as $record) {
+		$row = array();
+
+		foreach ($record as $r) {
+			$a = explode(':', $r);
+			$key = array_shift($a);
+			$info = implode(':', $a);
+			$row[strtolower(trim($key))] = trim($info);
+		}
+
+		$insert->execute(array($row['category'], $row['question'], $row['answer'], $row['regexp']));
+	}
+
+	fclose($fh);
+}
+$db->commit();

--- a/Phergie/Plugin/Trivia/questions.txt
+++ b/Phergie/Plugin/Trivia/questions.txt
@@ -1,0 +1,5765 @@
+Category: Americanisms
+Question: Britains say 'tarmac'; Americans say ······.
+Answer: runway
+
+Category: Americanisms
+Question: Britains say 'lift'; Americans say ······.
+Answer: elevator
+
+Category: Analogies
+Question: Analogy: 'Ancient' is to 'old' as 'recent' is to ········.
+Answer: current
+
+Category: Analogies
+Question: Bull - cow as fox - ··········.
+Answer: vixen
+
+Category: Analogies
+Question: Goose - geese as passerby - ···········.
+Answer: passersby
+
+Category: Anatomy
+Question: Your ···· holds your head to your shoulders.
+Answer: neck
+
+Category: Arts
+Question: In what field of study would you find "flying buttresses"?
+Answer: architecture
+
+Category: Arts
+Question: The study of building design is ············.
+Answer: architecture
+
+Category: Arts
+Question: This statue was found on the Greek island of Melos in 1820.
+Answer: Venus de Milo
+
+Category: Arts
+Question: Three main types of Greek columns are Doric, Ionic, and ··········.
+Answer: Corinthian
+
+Category: Arts
+Question: What Dutch master painted 64 self-portraits?
+Answer: Rembrandt
+
+Category: Arts
+Question: Where is the Louvre located?
+Answer: Paris
+
+Category: Arts
+Question: Who painted the Mona Lisa?
+Answer: Leonardo #da Vinci#
+
+Category: Astrology
+Question: What is the only sign in the zodiac which doesn't represent a living thing?
+Answer: Libra
+
+Category: Astrology
+Question: Which month has a diamond as a birthstone?
+Answer: April
+
+Category: Astronomy
+Question: A heavenly body moving under the attraction of the Sun and consisting of a nucleus and a tail is a(n) ·····.
+Answer: comet
+
+Category: Astronomy
+Question: Does Uranus have an aurora?
+Answer: yes
+
+Category: Astronomy
+Question: From 1979 until 2000 the most distant planet from the earth was ·······.
+Answer: Neptune
+
+Category: Astronomy
+Question: How many planets are there in our solar system?
+Answer: nine
+Regexp: (nine|9)
+
+Category: Astronomy
+Question: If you're in the northern hemisphere, Polaris, the North Star, can be found by looking which direction?
+Answer: north
+
+Category: Astronomy
+Question: Name the largest planet in the solar system.
+Answer: Jupiter
+
+Category: Astronomy
+Question: Name the second-largest planet in the solar system.
+Answer: saturn
+
+Category: Astronomy
+Question: Our galaxy is commonly known as the ········.
+Answer: Milky Way
+
+Category: Astronomy
+Question: The Big Dipper is part of what constellation?
+Answer: Ursa Major
+
+Category: Astronomy
+Question: The North Star is also known as ·······.
+Answer: Polaris
+
+Category: Astronomy
+Question: The fourth planet from the sun is ····.
+Answer: Mars
+
+Category: Astronomy
+Question: The name for the group of stars which form a hunter with a club and shield is ·····.
+Answer: Orion
+
+Category: Astronomy
+Question: The planet closest to the sun is ·······.
+Answer: Mercury
+
+Category: Astronomy
+Question: The spiral galaxy nearest ours is the ········· galaxy.
+Answer: Andromeda
+
+Category: Astronomy
+Question: The tides on the earth's oceans are actually created by gravitational pull from the ····.
+Answer: Moon
+
+Category: Astronomy
+Question: This cluster of stars is also known as the Seven Sisters.
+Answer: Pleiades
+
+Category: Astronomy
+Question: This comet appears every 76.3 years.
+Answer: Comet #Halley#
+
+Category: Astronomy
+Question: This planet's diameter is most equal to that of the earth's.
+Answer: Venus
+
+Category: Astronomy
+Question: What does "Ursa Major" mean in everyday English?
+Answer: great bear
+
+Category: Astronomy
+Question: What is the astronomical name for a group of stars?
+Answer: constellation
+
+Category: Astronomy
+Question: What is the name for the theoretical end-product of the gravitational collapse of a massive star?
+Answer: black hole
+
+Category: Astronomy
+Question: What is the name used to describe the "minor planets"?
+Answer: asteroids
+
+Category: Astronomy
+Question: What is the ocean of air around the earth called?
+Answer: atmosphere
+
+Category: Astronomy
+Question: What is the proper name for falling stars?
+Answer: meteors
+
+Category: Astronomy
+Question: What is the term for the path followed a by a small body around a massive body in space?
+Answer: orbit
+
+Category: Astronomy
+Question: What phenomenon is caused by the gravitational attraction of the moon?
+Answer: tides
+
+Category: Astronomy
+Question: What planet boasts the Great Red Spot?
+Answer: Jupiter
+
+Category: Bet you don't know ;-)
+Question: The two sexes of humans are male and ······?
+Answer: female
+
+Category: Biochemistry
+Question: This poisonous, oily liquid occurs in tobacco leaves.
+Answer: nicotine
+
+Category: Biochemistry
+Question: This protein makes the blood red in color.
+Answer: Haemoglobin
+Regexp: Ha?emoglobin
+
+Category: Biology
+Question: Every human has one of these on their tummies.
+Answer: navel
+
+Category: Biology
+Question: How many large holes are in your head?
+Answer: seven
+Regexp: (seven|7)
+
+Category: Biology
+Question: This complex substance makes up all living things.
+Answer: protoplasm
+
+Category: Biology
+Question: What is normal body temperature for an adult human (in degrees fahrenheit)?
+Answer: 98.6
+
+Category: Botany
+Question: The practice of joining the parts of two plants to make them grow as one is called ········.
+Answer: grafting
+
+Category: Botany
+Question: These flowerless plants grow on bare rocks and tree stumps.
+Answer: lichen
+
+Category: Botany
+Question: This fruit has its seeds on the outside.
+Answer: strawberry
+
+Category: Botany
+Question: This term means 'cone-bearing trees'.
+Answer: conifers
+
+Category: Botany
+Question: What fruit bear the latin name "citrus grandis"?
+Answer: grapefruit
+
+Category: Calendar
+Question: How many days where there in 1976?
+Answer: three hundred and sixty six
+Regexp: (three hundred (and )?sixty[- ]six|366)
+
+Category: Cartoon Trivia
+Question: Alvin & Simon had a brother called ····.
+Answer: Theodore
+Regexp: (theodore|theo)
+
+Category: Cartoon Trivia
+Question: An Andy Panda cartoon gave birth to a famous, cantankerous bird. Name him.
+Answer: Woody Woodpecker
+
+Category: Cartoon Trivia
+Question: An adventurous penguin named Tennessee Tuxedo had a sidekick named ·······?
+Answer: Chumley
+
+Category: Cartoon Trivia
+Question: An alien creature in a funny hat has opposed both Bugs Bunny and Daffy Duck.  Where is he from?
+Answer: Mars
+
+Category: Cartoon Trivia
+Question: Before Olive Oil met Popeye she was engaged to someone.  Who was he?
+Answer: Ham Gravy
+
+Category: Cartoon Trivia
+Question: Benny and Cecil were at odds with whom?
+Answer: John
+
+Category: Cartoon Trivia
+Question: Bugs always finds himself at the wrong end of a gun, usually toted by either Elmer Fudd or who?
+Answer: Yosemite Sam
+
+Category: Cartoon Trivia
+Question: Casper the Friendly Ghost frolicked with which witch?
+Answer: Wendy
+
+Category: Cartoon Trivia
+Question: Charles Boyer inspired a cartoon skunk. Who?
+Answer: Pepe le Pew
+
+Category: Cartoon Trivia
+Question: Famous Phrases: Who knows? The ······.
+Answer: Shadow
+
+Category: Cartoon Trivia
+Question: Gadzookie has a large, green friend. Who is he?
+Answer: Godzilla
+
+Category: Cartoon Trivia
+Question: Hanna-Barbera rose to fame by creating what duo for MGM?
+Answer: Tom and Jerry
+
+Category: Cartoon Trivia
+Question: How does Wonder Woman control her invisible airplane?
+Answer: #mental# powers
+Regexp: (mental|mind|brain|tele(pathy|kinesis))
+
+Category: Cartoon Trivia
+Question: In the cartoons who was Hokie Wolf's sidekick?
+Answer: Ding
+
+Category: Cartoon Trivia
+Question: In what city does Fat Albert live?
+Answer: Philadelphia
+
+Category: Cartoon Trivia
+Question: Mentor of Titan had two children in the Marvel comics, Thanos and ···?
+Answer: Ero
+
+Category: Cartoon Trivia
+Question: Miss Buckley is secretary to what commanding officer?
+Answer: General Halftrack
+
+Category: Cartoon Trivia
+Question: Name Alley Oop's girl friend.
+Answer: Oola
+
+Category: Cartoon Trivia
+Question: Name Cathy's on again/off again boy friend?
+Answer: Irving
+
+Category: Cartoon Trivia
+Question: Name Dennis the Menace's next door neighbors.
+Answer: Mr and Mrs #Wilson#
+
+Category: Cartoon Trivia
+Question: Name Donald Duck's girlfriend?
+Answer: Daisy
+
+Category: Cartoon Trivia
+Question: Name Hagar the Horrible's dog.
+Answer: Snert
+
+Category: Cartoon Trivia
+Question: Name Li'l Abner's favorite Indian drink.
+Answer: Kickapoo Joy Juice
+
+Category: Cartoon Trivia
+Question: Name the European hit, now an animated series about underwater people.
+Answer: The #Snork#s
+
+Category: Cartoon Trivia
+Question: Name the apartments the Jetson's live in.
+Answer: The #Skypad# Apartments
+
+Category: Cartoon Trivia
+Question: Name the dog in the Yankee Doodle cartoons.
+Answer: Chopper
+
+Category: Cartoon Trivia
+Question: Name the fastest mouse in all of Mexico.
+Answer: Speedy Gonzalez
+
+Category: Cartoon Trivia
+Question: Name the ranger who was always after Yogi Bear.
+Answer: Rick
+
+Category: Cartoon Trivia
+Question: Name the town that Fred, Wilma, Barney, and Betty lived in.
+Answer: Bedrock
+
+Category: Cartoon Trivia
+Question: On what T.V. show could Tom Terrific be found?
+Answer: Captain Kangaroo
+
+Category: Cartoon Trivia
+Question: Popeye's chief adversary has two names, Bluto and ······?
+Answer: Brutus
+
+Category: Cartoon Trivia
+Question: Porky Pig had a girlfriend named ········.
+Answer: Petunia
+
+Category: Cartoon Trivia
+Question: Tess Trueheart married which plainclothes detective?
+Answer: Dick Tracy
+
+Category: Cartoon Trivia
+Question: What came out of Milton's head?
+Answer: steam
+
+Category: Cartoon Trivia
+Question: What character did Tex Avery first create upon arriving at MGM?
+Answer: Screwball Squirrel
+
+Category: Cartoon Trivia
+Question: What comic strip character is Beetle Bailey's sister?
+Answer: Lois (of Hi and #Lois#)
+
+Category: Cartoon Trivia
+Question: What did Dagwood give up to marry Blondie?
+Answer: A family #inheritance#
+
+Category: Cartoon Trivia
+Question: What did Peppermint Patty always call Charlie Brown?
+Answer: Chuck
+
+Category: Cartoon Trivia
+Question: What is Batman's butler Alfred's last name.
+Answer: Pennyworth
+
+Category: Cartoon Trivia
+Question: What is Blondie's maiden name?
+Answer: Oop
+
+Category: Cartoon Trivia
+Question: What is Dennis the Menace's last name?
+Answer: Mitchell
+
+Category: Cartoon Trivia
+Question: What is Smokey Stover's job?
+Answer: fireman
+
+Category: Cartoon Trivia
+Question: What is Super Chicken's partners name?
+Answer: Fred
+
+Category: Cartoon Trivia
+Question: What is the mother's name in Family Circus?
+Answer: Thelma
+
+Category: Cartoon Trivia
+Question: What is the name of Duddley Do-Right's horse?
+Answer: Horse
+
+Category: Cartoon Trivia
+Question: What is the name of the Family Circus's dog?
+Answer: Barf
+
+Category: Cartoon Trivia
+Question: What kind of dog is Scooby Doo?
+Answer: great dane
+
+Category: Cartoon Trivia
+Question: What type of plant does Broom Hilda sell?
+Answer: venus flytrap
+
+Category: Cartoon Trivia
+Question: What was Daffy Duck's favorite insult?
+Answer: #You're dispicable#!
+
+Category: Cartoon Trivia
+Question: What was George of the Jungle always running in to?
+Answer: A #tree#
+
+Category: Cartoon Trivia
+Question: What was the first cartoon to feature sound?
+Answer: Steamboat Willie
+Regexp: Steamboat Will(ie|y)
+
+Category: Cartoon Trivia
+Question: What was the name of George of the Jungle's pet elephant?
+Answer: Shep
+
+Category: Cartoon Trivia
+Question: What was the name of Speed Racer's car?
+Answer: The #Mach Five#
+Regexp: (Mach (Five|5))
+
+Category: Cartoon Trivia
+Question: What was the original name Charles Schultz had for Peanuts?
+Answer: Li'l Folks
+Regexp: Li'?l Folks
+
+Category: Cartoon Trivia
+Question: What was the relationship between Superman and Supergirl?
+Answer: cousin
+
+Category: Cartoon Trivia
+Question: When Tweety exclaimed, "I thought I saw a putty tat!", who did he see?
+Answer: Sylvester
+
+Category: Cartoon Trivia
+Question: When danger appeared, Quick Draw McGraw became which super hero?
+Answer: El KaBong
+
+Category: Cartoon Trivia
+Question: When not a Birdman, what does Ray Randall do for a living?
+Answer: #police# officer
+
+Category: Cartoon Trivia
+Question: When not fighting crime, what did Underdog do for a living?
+Answer: #shoeshine# boy
+
+Category: Cartoon Trivia
+Question: Where are Rocket J. Squirel and Bullwinkle Moose from?
+Answer: Frostbite Falls
+
+Category: Cartoon Trivia
+Question: Where did Clark Kent attend college?
+Answer: #Metropolis# University
+
+Category: Cartoon Trivia
+Question: Where did George of the Jungle live?
+Answer: Imgwee Gwee Valley
+
+Category: Cartoon Trivia
+Question: Where did Mighty Mouse get his superpowers?
+Answer: supermarket
+Regexp: super ?market
+
+Category: Cartoon Trivia
+Question: Where do Rocky and Bullwinkle play football?
+Answer: What'samatta University
+Regexp: What'?samatta U(niversity)?
+
+Category: Cartoon Trivia
+Question: Where does George Jetson work?
+Answer: Spacely Sprockets
+
+Category: Cartoon Trivia
+Question: Where does Yogi Bear Live?
+Answer: #Jellystone# Park
+
+Category: Cartoon Trivia
+Question: Which comic strip was banned from "Stars and Stripes"?
+Answer: Beetle Bailey
+
+Category: Cartoon Trivia
+Question: Which superhero loves peace enough to kill for it?
+Answer: Peacemaker
+
+Category: Cartoon Trivia
+Question: Who always tried to kill Krazy Kat?
+Answer: Captain Marvel
+
+Category: Cartoon Trivia
+Question: Who is Donald Duck's uncle?
+Answer: Scrooge
+
+Category: Cartoon Trivia
+Question: Who is Sally Brown's sweet baboo?
+Answer: Linus
+
+Category: Cartoon Trivia
+Question: Who is Scooby Doo's nephew??
+Answer: #Scrappy# Doo
+
+Category: Cartoon Trivia
+Question: Who is Snoopy's arch enemy?
+Answer: The #Red Baron#
+
+Category: Cartoon Trivia
+Question: Who is stationed at Camp Swampy in the comic strips?
+Answer: Beetle Bailey
+
+Category: Cartoon Trivia
+Question: Who runs Andy Capp's favorite pub?
+Answer: Jack and Jill
+
+Category: Cartoon Trivia
+Question: Who says, "Th-th-th-that's all folks!"
+Answer: Porky Pig
+
+Category: Cartoon Trivia
+Question: Who shot Bruce Wayne's parents?
+Answer: Chill
+
+Category: Cartoon Trivia
+Question: Who was Dick Dastardly's pet?
+Answer: Muttley
+
+Category: Cartoon Trivia
+Question: Who was always trying to get rent from Andy Capp?
+Answer: Percy
+
+Category: Cartoon Trivia
+Question: Who was the Hulk's first friend?
+Answer: Rick Jones
+
+Category: Cartoon Trivia
+Question: Who was the original voice of Mickey Mouse?
+Answer: Walt Disney
+
+Category: Chemistry
+Question: Hydrogen Hydroxide is more commonly known as what?
+Answer: water
+
+Category: Chemistry
+Question: Nitrogen, a poisonous gas, makes up 78% of the ··· that we breathe.
+Answer: air
+
+Category: Chemistry
+Question: Sodium Hydroxide is more commonly known as ···.
+Answer: lye
+
+Category: Chemistry
+Question: Sodium bicarbonate is better known as ·········.
+Answer: baking soda
+
+Category: Chemistry
+Question: The process of removing salt from sea water is known as ···········.
+Answer: desalination
+
+Category: Chemistry
+Question: The smallest portion of a substance capable of existing independently and retaining its original properties is a(n) ········.
+Answer: molecule
+
+Category: Chemistry
+Question: This ancient attempt to transmute base metals into gold was called ·······.
+Answer: alchemy
+
+Category: Chemistry
+Question: This is the heaviest naturally occurring element.
+Answer: uranium
+
+Category: Chemistry
+Question: This is the symbol for tin.
+Answer: Sn
+
+Category: Chemistry
+Question: This poisonous gas is in the exhaust fumes from cars.
+Answer: carbon monoxide
+
+Category: Chemistry
+Question: Water containing carbon dioxide under pressure is called ···· ·····.
+Answer: soda water
+
+Category: Chemistry
+Question: What is it that turns blue litmus paper red?
+Answer: acid
+
+Category: Chemistry
+Question: What is the abbreviation for trinitrotoluene?
+Answer: TNT
+
+Category: Chemistry
+Question: What is the chemical symbol for copper?
+Answer: Cu
+
+Category: Chemistry
+Question: What is the chemical symbol for gold?
+Answer: Au
+
+Category: Chemistry
+Question: What is the main component of air?
+Answer: nitrogen
+
+Category: Chemistry
+Question: What is the more scientific name for quicksilver?
+Answer: mercury
+
+Category: Chemistry
+Question: What is the symbol for iron in chemistry?
+Answer: Fe
+
+Category: Chemistry
+Question: What is the symbol for silver?
+Answer: Ag
+
+Category: Christmas
+Question: Name the loner rebel reindeer with the red shiny nose.
+Answer: Rudolph
+
+Category: Christmas
+Question: Santa Claus reportedly lives at the ····· Pole.
+Answer: north
+
+Category: Comic Strip Trivia
+Question: What comic strip is set at Camp Swampy?
+Answer: Beetle Bailey
+
+Category: Computer Science
+Question: That big square thing you're staring at right now is called a ·······?
+Answer: monitor
+
+Category: Computer Science
+Question: The Internet Relay Chat Program, which normally connects to port 6667, is more commonly known as ···.
+Answer: IRC
+
+Category: Definitions
+Question: --isms:  Exalting one's country above all others.
+Answer: nationalism
+
+Category: Definitions
+Question: --isms:  The belief that there is no God.
+Answer: atheism
+
+Category: Definitions
+Question: --isms:  The theory that man cannot prove the existence of a god.
+Answer: agnosticism
+
+Category: Definitions
+Question: -ism: The belief in the existence of a god or gods.
+Answer: theism
+
+Category: Definitions
+Question: -isms: A diseased condition resulting from the use of beverages such as whiskey.
+Answer: alcoholism
+
+Category: Definitions
+Question: -isms: A one-party system of government in which control is maintained by force and regimentation.
+Answer: fascism
+
+Category: Definitions
+Question: -isms: A painful stiffness of the muscles and joints
+Answer: rheumatism
+
+Category: Definitions
+Question: -isms: A severe or unfavorable judgment.
+Answer: criticism
+
+Category: Definitions
+Question: -isms: An economic system characterized by private ownership and competition.
+Answer: capitalism
+
+Category: Definitions
+Question: -isms: Excessive emphasis on financial gain.
+Answer: commercialism
+
+Category: Definitions
+Question: -isms: Excessive enthusiasm or zeal for a cause.
+Answer: fanaticism
+
+Category: Definitions
+Question: -isms: Poisoning caused by a toxin in improperly prepared food.
+Answer: botulism
+
+Category: Definitions
+Question: -isms: Public ownership of the basic means of production, distribution, and exchange.
+Answer: socialism
+
+Category: Definitions
+Question: -isms: The belief in living a very austere and self-denying life.
+Answer: asceticism
+
+Category: Definitions
+Question: A clip, shaped like a bar to keep a woman's hair in place is a ·······.
+Answer: barrette
+
+Category: Definitions
+Question: A depilatory is a substance used for removing ····.
+Answer: hair
+
+Category: Definitions
+Question: A device used to change the voltage of alternating currents is a ··········.
+Answer: transformer
+
+Category: Definitio octagon
+
+Category: Definitions
+Question: What is another name for a tombstone inscription?
+Answer: epitaph
+
+Category: Definitions
+Question: What is measured by a chronometer?
+Answer: time
+
+Category: Definitions
+Question: What is the common name for a Japanese dwarf tree?
+Answer: bonsai
+
+Category: Definitions
+Question: What is the common name for the Aurora Borealis?
+Answer: northern lights
+
+Category: Definitions
+Question: What is the common term for a "somnambulist"?
+Answer: sleepwalker
+
+Category: Definitions
+Question: What is the name for a branch of a river?
+Answer: tributary
+
+Category: Definitions
+Question: What is the study of heredity called?
+Answer: genetics
+
+Category: Definitions
+Question: What is the study of prehistoric plants and animals called?
+Answer: paleontology
+
+Category: Definitions
+Question: What is the term for a castrated rooster?
+Answer: capon
+
+Category: Definitions
+Question: Which science studies weather?
+Answer: meteorology
+
+Category: Domestic Metallurgy
+Question: Name the clothing wrinkle remover that sounds like a kind of metal.
+Answer: iron
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: A 3 1/2" floppy disk measures ··· and 1/2 inches across.
+Answer: 3
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: A brown crayon is what color?
+Answer: brown
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: A smoke detector will alarm if it detects ·····.
+Answer: smoke
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: A water heater keeps ····· warm for you.
+Answer: water
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: Although not all come from France, ······ fries are often served with hamburgers.
+Answer: french
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: An ····· clock usually wakes you in the morning.
+Answer: alarm
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: During the American Revolution, the Boston Tea Party took place in ······ Harbor.
+Answer: boston
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: How do you spell abbreviation?
+Answer: abbreviation
+
+Category: Don't Strain Yourself Thinking ;-)
+Question: How many pencils are there in a dozen?
+Answer: twelve
+Regexp: (twelve|12)
+
+Category: Drama
+Question: "Our Town" is a play by whom?
+Answer: Thornton #Wilder#
+
+Category: Drama
+Question: The play "Our Town" is set where?
+Answer: Grover's Corners
+Regexp: Grover'?s Corner
+
+Category: Fantasy
+Question: What is a sorcerer who deals in black magic called?
+Answer: necromancer
+
+Category: Food
+Question: Boston butt, jowl, and picnic ham are parts of a ······.
+Answer: pig
+
+Category: Food and Drink
+Question: Even though it tastes nothing like grapes, a ·········· is often eaten for breakfast.
+Answer: grapefruit
+
+Category: Food and Drink
+Question: From what animal do we get venison?
+Answer: deer
+
+Category: Food and Drink
+Question: From which fish is caviar obtained?
+Answer: sturgeon
+
+Category: Food and Drink
+Question: From which fruit is the liqueur Kirsh made?
+Answer: cherry
+
+Category: Food and Drink
+Question: Iceberg, Boston, and Bibb are types of ·········.
+Answer: lettuce
+
+Category: Food and Drink
+Question: Laetrile is associated with the pit of which fruit?
+Answer: apricot
+
+Category: Food and Drink
+Question: Little round chocolate candies are known as _&m's.
+Answer: m
+
+Category: Food and Drink
+Question: Mustard, ketchup and onions on a hotdog are all ··········.
+Answer: condiments
+
+Category: Food and Drink
+Question: Name the only fruit named for its color.
+Answer: orange
+
+Category: Food and Drink
+Question: Natural vanilla flavoring comes from this plant.
+Answer: orchid
+
+Category: Food and Drink
+Question: Often drunk, this liquid is normally harvested from female cows.
+Answer: milk
+
+Category: Food and Drink
+Question: Often eaten for breakfast, bacon is actually the flesh of what barnyard animal?
+Answer: pig
+
+Category: Food and Drink
+Question: Often eaten for breakfast, the egg comes from what barnyard animal?
+Answer: chicken
+
+Category: Food and Drink
+Question: Rum is made from this plant.
+Answer: sugar cane
+
+Category: Food and Drink
+Question: Vermicelli literally means ···········.
+Answer: little worms
+
+Category: Food and Drink
+Question: What do you get when you add fresh fruit to red wine?
+Answer: sangria
+
+Category: Food and Drink
+Question: What is Japanese "sake" made from?
+Answer: rice
+
+Category: Food and Drink
+Question: What is the name of the syrup drained from raw sugar?
+Answer: molasses
+
+Category: Food and Drink
+Question: What kind of nuts are used in marzipan?
+Answer: almonds
+
+Category: Food and Drink
+Question: Where is the best brandy bottled?
+Answer: cognac
+
+Category: Food and Drink
+Question: Where was Budweiser first brewed?
+Answer: St. Louis
+Regexp: St.? Louis
+
+Category: Fun
+Question: Cocktails: Bourbon, sugar and mint make a(n) ···········.
+Answer: mint julep
+
+Category: Fun
+Question: Cocktails: Cognac (brandy) and white creme de menthe make a(n) ·············.
+Answer: stinger
+
+Category: Fun
+Question: Cocktails: Creme de Cacao, cream, and brandy make a(n) ··········.
+Answer: brandy alexander
+
+Category: Fun
+Question: Cocktails: Gin and Collins mix make a(n) ··········.
+Answer: Tom Collins
+
+Category: Fun
+Question: Cocktails: Rum, lime, and cola drink make a(n) ············.
+Answer: cuba libre
+
+Category: Fun
+Question: Cocktails: Triple sec, tequila, and lemon or lime juice make a(n) ·········.
+Answer: margarita
+
+Category: Fun
+Question: Cocktails: Vodka and Kahlua make a ···········.
+Answer: black russian
+
+Category: Fun
+Question: Cocktails: Vodka, orange juice and Galliano make a(n) ···········.
+Answer: Harvey Wallbanger
+
+Category: Fun
+Question: Cocktails: Whiskey, hot coffee, and whipped cream make a(n) ·········.
+Answer: Irish coffee
+
+Category: Games
+Question: A bridge hand with no cards in one suit is said to have a ·······.
+Answer: void
+
+Category: Games
+Question: A poker hand consisting of three of a kind and a pair is called a ·······.
+Answer: full house
+
+Category: Games
+Question: How many balls are used in a game of snooker including the cue ball?
+Answer: twenty two
+Regexp: (twenty[- ]two|22)
+
+Category: Games
+Question: How many dots are there on a pair of dice?
+Answer: forty two
+Regexp: (forty[- ]two|42)
+
+Category: Games
+Question: How many squares are there on a chessboard?
+Answer: sixty four
+Regexp: (sixty[- ]four|64)
+
+Category: Games
+Question: If you "peg out" what game are you playing?
+Answer: cribbage
+
+Category: Games
+Question: In poker five cards of the same suit is called a(n) ········.
+Answer: flush
+
+Category: Games
+Question: In pool, what color is the eight ball?
+Answer: black
+
+Category: Games
+Question: In which game might a person have a "full house"?
+Answer: poker
+
+Category: Games
+Question: In which game or sport are "Staunton" pieces used?
+Answer: chess
+
+Category: Games
+Question: In which game or sport can a person be "skunked"?
+Answer: cribbage
+
+Category: Games
+Question: In which sport are terms "spare" and "gutter" used?
+Answer: tenpin #bowling#
+
+Category: Games
+Question: In which sport or game are the terms: 'pin', 'fork', and 'skewer' used?
+Answer: chess
+
+Category: Games
+Question: In which sport or game is the term "rook" used?
+Answer: chess
+
+Category: Games
+Question: Name the only flexible murder weapon in the game of "Clue".
+Answer: rope
+
+Category: Games
+Question: Name the only woman suspect in the game of "Clue" who isn't married.
+Answer: Miss #Scarlett#
+
+Category: Games
+Question: These are the two highest valued letters in "Scrabble".  "Q" and ·····.
+Answer: Z
+
+Category: Games
+Question: This ancient Chinese game is played with 156 small rectangular tiles.
+Answer: mah jongg
+Regexp: mah? ?jong
+
+Category: Games
+Question: This is the lowest ranking suit in Bridge.
+Answer: clubs
+
+Category: Games
+Question: This term denotes a chess move in which both the king and the rook are moved.
+Answer: castling
+
+Category: Games
+Question: What bowling term means three straight strikes?
+Answer: turkey
+
+Category: Games
+Question: What game or sport is Bobby Fischer identified with?
+Answer: chess
+
+Category: Games
+Question: What number is on the opposite side of the "five" on dice?
+Answer: two
+Regexp: (two|2)
+
+Category: Games
+Question: What score is not possible for a cribbage hand?
+Answer: nineteen
+Regexp: (nineteen|19)
+
+Category: Games
+Question: Which chess piece is usually valued as 5 points?
+Answer: rook
+
+Category: Games
+Question: Which game usually begins with, "Is it animal, vegetable, or mineral?"
+Answer: twenty questions
+Regexp: (twenty|20) questions
+
+Category: General Knowledge
+Question: Although it doesn't sound like a dog, ····dust is ornamental wood chips often placed in flowerbeds.
+Answer: bark
+
+Category: General Knowledge
+Question: Chicago Transit Authority is now known as which group?
+Answer: Chicago
+
+Category: General Knowledge
+Question: If you drive on a parkway, you park on a ·······?
+Answer: driveway
+
+Category: General Knowledge
+Question: To refuel your car you go to a ····· station.
+Answer: petrol
+
+Category: General Knowledge
+Question: Wedding rings are normally worn on what finger of your hand?
+Answer: #ring# finger
+
+Category: General Knowledge
+Question: What are catalogued under the Dewey decimal system?
+Answer: books
+
+Category: General Knowledge
+Question: What are the 3 big colleges of the Ivy League? (name them alphabetically)
+Answer: Harvard, Princeton, Yale
+Regexp: Harvard,? Princeton,?( and)? Yale
+
+Category: General Knowledge
+Question: What company makes Pampers disposable diapers?
+Answer: Proctor & Gamble
+Regexp: Proctor (&|and) Gamble
+
+Category: General Knowledge
+Question: What do the initials U.F.O stand for?
+Answer: Unidentified Flying Object
+
+Category: General Knowledge
+Question: What do the letters in SAM missiles refer to?
+Answer: Surface-to-Air Missile
+Regexp: Surface[- ]to[- ]Air
+
+Category: General Knowledge
+Question: What does IRS stand for?
+Answer: Internal Revenue Service
+
+Category: General Knowledge
+Question: What does a compass needle point to?
+Answer: north
+
+Category: General Knowledge
+Question: What does the abbreviation a.m. stand for?
+Answer: Ante Meridian
+
+Category: General Knowledge
+Question: What does the acronym CIA stand for?
+Answer: Central Intelligence Agency
+
+Category: General Knowledge
+Question: What is the minimum IQ score for the genius category?
+Answer: one hundred and forty
+Regexp: (one hundred (and |& )?forty|140)
+
+Category: General Knowledge
+Question: What is this sign called "&"?
+Answer: ampersand
+
+Category: General Knowledge
+Question: When using a telephone, you must wait for a ···· tone before starting your call.
+Answer: dial
+
+Category: General Knowledge
+Question: Which U.S. president is on the five-dollar bill?
+Answer: Abraham #Lincoln#
+
+Category: Geography
+Question: Acadia was the original name of which Canadian province?
+Answer: Nova Scotia
+
+Category: Geography
+Question: Bridgeport is the largest city in which state?
+Answer: Connecticut
+
+Category: Geography
+Question: Bridgetown is the capital of ········.
+Answer: Barbados
+
+Category: Geography
+Question: Brussels is the capital of which country?
+Answer: Belgium
+
+Category: Geography
+Question: Frankfort is the capital of which state?
+Answer: Kentucky
+
+Category: Geography
+Question: Guayaquil is the largest city in what country?
+Answer: Ecuador
+
+Category: Geography
+Question: Halifax is the capital of which Canadian province?
+Answer: Nova Scotia
+
+Category: Geography
+Question: Havana is the capital of which country?
+Answer: Cuba
+
+Category: Geography
+Question: He invented the most common projection for world maps.
+Answer: Gerardus #Mercator#
+
+Category: Geography
+Question: He visited Australia and New Zealand, then surveyed the Pacific Coast of North America.
+Answer: Vancouver
+
+Category: Geography
+Question: How many stars are on the flag of New Zealand?
+Answer: four
+Regexp: (four|4)
+
+Category: Geography
+Question: If its 4:00pm in Seattle, Washington what time is it in Portland, Oregon?
+Answer: #4#:00pm
+
+Category: Geography
+Question: In what city are the famous Tivoli Gardens?
+Answer: Copenhagen
+
+Category: Geography
+Question: In what city is the Leaning Tower?
+Answer: Pisa
+
+Category: Geography
+Question: In what city is the Smithsonian Institute?
+Answer: Washington
+
+Category: Geography
+Question: In what country is Banff National Park?
+Answer: Canada
+
+Category: Geography
+Question: In what country is Lahore?
+Answer: Pakistan
+
+Category: Geography
+Question: In what country is Mandalay?
+Answer: #Myanmar# (formerly known as Burma)
+Regexp: (Myanmar|Burma)
+
+Category: Geography
+Question: In what country is Taipei?
+Answer: Taiwan
+
+Category: Geography
+Question: In what country is Thunder Bay?
+Answer: Canada
+
+Category: Geography
+Question: In what country is the Jutland peninsula?
+Answer: Denmark
+
+Category: Geography
+Question: In what country is the Mekong River Delta?
+Answer: Vietnam
+
+Category: Geography
+Question: In what country is the Waterloo battlefield?
+Answer: Belgium
+
+Category: Geography
+Question: In what country is the highest point in South America?
+Answer: Argentina
+
+Category: Geography
+Question: In what country is the lowest point in South America?
+Answer: Argentina
+
+Category: Geography
+Question: In what country is the source of the Blue Nile?
+Answer: Ethiopia
+
+Category: Geography
+Question: In what island group is Corregidor?
+Answer: #Philippine#s
+
+Category: Geography
+Question: In what mountain range is Kicking Horse Pass?
+Answer: Rocky
+Regexp: Rock(y|ies)
+
+Category: Geography
+Question: In what state is Concord?
+Answer: New Hampshire
+
+Category: Geography
+Question: In which city is Red Square?
+Answer: Moscow
+
+Category: Geography
+Question: In which city is Saint Paul's Cathedral?
+Answer: London
+
+Category: Geography
+Question: In which city is Wembley Stadium?
+Answer: London
+
+Category: Geography
+Question: In which city is the Bridge of Sighs?
+Answer: Venice
+
+Category: Geography
+Question: In which city is the C.N. Tower?
+Answer: Toronto
+
+Category: Geography
+Question: In which city is the Canale Grande?
+Answer: Venice
+
+Category: Geography
+Question: In which city is the Colliseum located?
+Answer: Rome
+
+Category: Geography
+Question: In which city is the Wailing Wall?
+Answer: Jerusalem
+
+Category: Geography
+Question: In which country is Angel Falls?
+Answer: Venezuela
+
+Category: Geography
+Question: In which country is Brest? (NOT Breast!)
+Answer: France
+
+Category: Geography
+Question: In which country is Chennai (formerly Madras)?
+Answer: India
+
+Category: Geography
+Question: In which country is Cusco?
+Answer: Peru
+
+Category: Geography
+Question: In which country is Loch Ness?
+Answer: Scotland
+
+Category: Geography
+Question: In which country is Normandy?
+Answer: France
+
+Category: Geography
+Question: In which country is Sapporo?
+Answer: Japan
+
+Category: Geography
+Question: In which country is the Calabria region?
+Answer: Italy
+
+Category: Geography
+Question: In which country is the Dalai Lama's palace?
+Answer: Tibet
+
+Category: Geography
+Question: In which country is the Great Victoria Desert?
+Answer: Australia
+
+Category: Geography
+Question: In which country is the Machu Picchu?
+Answer: Peru
+
+Category: Geography
+Question: In which country would you find the Yucatan Peninsula?
+Answer: Mexico
+
+Category: Geography
+Question: In which ocean or sea are the Seychelles?
+Answer: #Indian# Ocean
+
+Category: Geography
+Question: In which state are Gettysburg and the Liberty Bell?
+Answer: Pennsylvania
+
+Category: Geography
+Question: In which state are the Finger Lakes?
+Answer: New York
+
+Category: Geography
+Question: In which state is Appomattax?
+Answer: Virginia
+
+Category: Geography
+Question: In which state is Cape Hatteras?
+Answer: North Carolina
+
+Category: Geography
+Question: In which state is Hoover Dam?
+Answer: Arizona
+
+Category: Geography
+Question: In which state is Mount McKinley?
+Answer: Alaska
+
+Category: Geography
+Question: In which state is Mount St. Helens?
+Answer: Washington
+
+Category: Geography
+Question: In which state is Mount Vernon?
+Answer: Virginia
+
+Category: Geography
+Question: In which state is Stone Mountain?
+Answer: Georgia
+
+Category: Geography
+Question: In which state is Walla Walla?
+Answer: Washington
+
+Category: Geography
+Question: In which state is the Kennedy Space the winner of the NHL play-offs?
+Answer: Stanley Cup
+
+Category: Sport
+Question: What vehicles are involved in the "Tour de France"?
+Answer: bicycles
+
+Category: Sport
+Question: What was football player Dick Lane's nickname?
+Answer: Night Train
+
+Category: Sport
+Question: What's the nickname of the University of Georgia football team?
+Answer: Bulldogs
+
+Category: Sport
+Question: Where are the U.S. Tennis Open Championships held?
+Answer: #Flushing Meadows#, NY
+
+Category: Sport
+Question: Which NFL team's defensive unit was nicknamed "The Purple People Eaters"?
+Answer: Minnesota #Vikings#
+
+Category: Sport
+Question: Which country won the World Cup of Soccer in 1982.
+Answer: Italy
+
+Category: Sport
+Question: Which football team was nicknamed the "Orange Crush"?
+Answer: Denver #Broncos#
+
+Category: Sport
+Question: Which is the only position in soccer allowed to handle the ball?
+Answer: goalkeeper
+Regexp: (goalie|goalkeeper)
+
+Category: Sport
+Question: Which position is usually played by the tallest member on a basketball team?
+Answer: centre
+Regexp: cent(er|re)
+
+Category: Sport
+Question: Which sport has a movement called a "telemark"?
+Answer: skiing
+
+Category: Sport
+Question: Which sport uses stones and brooms?
+Answer: curling
+
+Category: Sport
+Question: Which swimming stroke is named after an insect?
+Answer: butterfly
+
+Category: Sport
+Question: Who was known as the "Sultan of Swat"?
+Answer: Babe Ruth
+
+Category: Sport
+Question: Who was the 1978 Wimbledon Women's Singles champ?
+Answer: Martina Navratilova
+
+Category: Sport
+Question: Who was the first NHL player to score 50 goals in one season?
+Answer: Maurice #Richard# <-- pronounced "Reeee-shard"
+
+Category: Sport
+Question: Who was the first to win the grand slam of tennis?
+Answer: Don #Budge#
+
+Category: Sport
+Question: With which sport is Chris Evert Lloyd identified?
+Answer: tennis
+
+Category: Stand on your heads.... NOW! ;-)
+Question: When read upside down, what does the term "umop apisdn" signify?
+Answer: upside down
+
+Category: Stupid things to do ;-)
+Question: If you look at the sun long enough, you go ·····.
+Answer: blind
+
+Category: Summertime
+Question: This is the sandy area nearest the ocean.
+Answer: beach
+
+Category: TV Trivia
+Question: What did TVs IMF stand for?
+Answer: Impossible Mission Forces
+
+Category: TV Trivia
+Question: What was the first network series devoted entirely to rock and roll?
+Answer: American Bandstand
+
+Category: TV Trivia
+Question: Who was Carl in Five Easy Pieces before going to Walton's Mountain?
+Answer: Waite
+
+Category: TV Trivia
+Question: Who was Chief Marshall of the Mickey Mouse Club?
+Answer: Walt Disney
+
+Category: Triplets
+Question: Hook, line and ···········.
+Answer: sinker
+
+Category: Trivia
+Question: "7X" was used to refer to the secret ingredient of which drink?
+Answer: Coca Cola
+
+Category: Trivia
+Question: A "pigskin" is another name for a(n) ········.
+Answer: football
+
+Category: Trivia
+Question: A can of Pepsi holds ·· fluid ounces.
+Answer: twelve
+Regexp: (twelve|12)
+
+Category: Trivia
+Question: A foot-long ruler is ·· inches long.
+Answer: twelve
+Regexp: (twelve|12)
+
+Category: Trivia
+Question: Most men do this each morning, using a razor.
+Answer: shave
+
+Category: Trivia
+Question: Most people wear a watch on their ···· wrist.
+Answer: left
+
+Category: Trivia
+Question: Name the implement that removes water from your windshield on your car?
+Answer: wiper
+
+Category: Trivia
+Question: Traffic Trivia:  Red means stop, ····· means go.
+Answer: green
+
+Category: Trivia
+Question: What US state has the Worlds Champion Chili Cookoff every year?
+Answer: Texas
+
+Category: Trivia
+Question: What bit of Bobby Goldsboro syrup focused on a dying young wife?
+Answer: honey
+
+Category: Trivia
+Question: What did Sally Rogers always wear in her hair?
+Answer: a #bow#
+
+Category: Trivia
+Question: What does the typical American eat 263 of each year? not pizza!!
+Answer: eggs
+
+Category: Trivia
+Question: What game show had people dressed up funny?
+Answer: Let's #Make A Deal#
+
+Category: Trivia
+Question: What is Grimace of the McDonald's characters?
+Answer: A #tastebud#
+
+Category: Trivia
+Question: What was Simple Simon fishing for in his mother's pail?
+Answer: whale
+
+Category: Trivia
+Question: What was the name of the Akla-Seltzer boy?
+Answer: Speedy
+
+Category: Trivia
+Question: What was the name of the dog in RCA Victor's trademark?
+Answer: Nipper
+
+Category: Trivia
+Question: What's the telephone area code for Chicago?
+Answer: 312
+
+Category: Trivia
+Question: Where did Howdy Doody live?
+Answer: Doodyville
+
+Category: Trivia
+Question: Where were Archie and Edith Bunker's chairs enshrined?
+Answer: The #Smithsonian# Institute
+
+Category: Trivia
+Question: Who is also known as Mr. Warmth?
+Answer: Don #Rickles#
+
+Category: Trivia
+Question: Who is known as "the world's oldest teenager"?
+Answer: Dick #Clark#
+
+Category: Word Asssociation
+Question: Ball and ········.
+Answer: chain
+
+Category: Word Asssociation
+Question: Peace and ·········.
+Answer: quiet
+
+Category: Word Asssociation
+Question: Which word is related to these three: nap, walk, call?
+Answer: cat
+
+Category: Word Asssociation
+Question: Which word is related to these three: painting, bowl, nail?
+Answer: finger
+
+Category: Word Asssociation
+Question: Which word is related to these three: rat, blue, cottage?
+Answer: cheese
+
+Category: Words containing 'for'
+Question: A castle or enclosed place.
+Answer: FORt
+
+Category: Words containing 'for'
+Question: Make holes through something.
+Answer: perFORate
+
+Category: Words containing 'for'
+Question: Many trees.
+Answer: FORest
+
+Category: Words containing 'for'
+Question: Pardon.
+Answer: FORgive
+
+Category: Words containing 'ten'
+Question: A choice cut of meat.
+Answer: tenderloin
+
+Category: (Definitions: -isms)
+Question: Sartre, de Beauvoir and Camus all belonged to this philosophical movement.
+Answer: Existentialism
+
+Category: -isms
+Question: Indifference to pleasure or pain; Greek philosophical system following the teachings of Zeno.
+Answer: stoicism
+
+Category: -ologies
+Question: A collection of literary pieces?
+Answer: anthology
+
+Category: -ologies
+Question: The study of animal and plant tissues?
+Answer: Histology
+
+Category: Abbreviations
+Question: What does SOS stand for
+Answer: Save Our Souls
+
+Category: Abbreviations
+Question: What does the abbreviation N/A mean?
+Answer: not applicable
+
+Category: Advertising
+Question: What statuette is awarded annually for the best television commercial?
+Answer: Clio
+
+Category: Air Travel
+Question: What is the national airline of Indonesia?
+Answer: Garuda
+
+Category: Alcohol
+Question: What do the letters VSOP on a brandy bottle stand for?
+Answer: Very Special Old Pale
+
+Category: Americans are Silly
+Question: There are 4 towns in the United States with the name of what other bird in their names?
+Answer: chicken
+
+Category: Americans are Silly
+Question: There are 61 towns in the United States with the name of what bird in their names?
+Answer: Turkey
+
+Category: Anatomy
+Question: A mouth-like opening into the body; also the porous openings on the surface of leaves.
+Answer: stomata
+
+Category: Anatomy
+Question: After a bolus has been digested in the stomach, it is called ______ as it moves into the small intestine.
+Answer: chyme
+
+Category: Anatomy
+Question: These essential body cells do not contain nuclei?
+Answer: Red Blood Cells
+
+Category: Anatomy
+Question: These glands are located on top of the kidneys.
+Answer: Adrenal
+
+Category: Anatomy
+Question: This organ of the excretory system is composed of small tubules called nephridia?
+Answer: kidney
+
+Category: Anatomy
+Question: What is the term for a mass of mood moving from your mouth to your stomach called?
+Answer: bolus
+
+Category: Anatomy
+Question: What period takes place shortly after chilbrith?
+Answer: postpartum
+
+Category: Anatomy
+Question: Whats the technical name for the skull ?
+Answer: Cranium
+
+Category: Anatomy and Physiology
+Question: These essential body cells do not contain nuclei.
+Answer: #red blood# cells
+
+Category: Ancient Stuff
+Question: The Colosseum received its name not for its size, but for a colossal statue of who that stood close by?
+Answer: Nero
+
+Category: Animal Kingdom
+Question: In the animal kingdom, if reptiles are in class reptilia, then birds are in class ____
+Answer: aves
+
+Category: Animal Kingdom
+Question: Often hunted for its fur, this South American rodent bathes in dust and is often sold in the pet trade.
+Answer: chinchilla
+
+Category: Animal Kingdom
+Question: On Borneo and Sumatra, the literal translation of this ape's name means "man of the forest."
+Answer: Orang-utan
+Regexp: orang[- ]?utan
+
+Category: Animal Kingdom
+Question: Term for an emasculated male pig
+Answer: barrow
+
+Category: Animal Kingdom
+Question: The Komodo Dragon, the biggest known lizard to science, is endemic to the Komodo islands of what country?
+Answer: Indonesia
+
+Category: Animal Kingdom
+Question: The closest living relative of this African mammal is the giraffe.
+Answer: Okapi
+
+Category: Animal Kingdom
+Question: The insect class "hymenoptera" includes ants and these colonial honey-makers.
+Answer: bees
+
+Category: Animal Kingdom
+Question: The silkworm only eats the leaves of what plant?
+Answer: mulberry
+
+Category: Animal Kingdom
+Question: What aminal is the logo of the World Wildlife Fund?
+Answer: panda
+
+Category: Animal Kingdom
+Question: Which is a small flightless bird, also New Zealand's national symbol?
+Answer: kiwi
+
+Category: Animal Kingdom
+Question: Which plant is known for attracting hummingbirds?
+Answer: hibiscus
+
+Category: Animals
+Question: The greyhound, along with this smaller relative, is used in the sport of coursing.
+Answer: whippet
+
+Category: Animals
+Question: What is the fastest breed of dog after the greyhound?
+Answer: whippet
+
+Category: Architecture
+Question: A receptacle for holy water in a church is a ....?
+Answer: font
+
+Category: Architecture
+Question: Towards which direction does the Tower of Pisa lean?
+Answer: south
+
+Category: Art
+Question: French impressionist Claude -----
+Answer: Monet
+
+Category: Art
+Question: Spanish modernist and cubist Pablo -------
+Answer: Picasso
+
+Category: Art
+Question: The surrealist painter Salvador Dali was a native of which country?
+Answer: Spain
+
+Category: Arts
+Question: In what opera would you find Lt. Pinkerton?
+Answer: Madame butterfly
+
+Category: Arts
+Question: What are arranged in the Japanese art of Ikebana?
+Answer: flowers
+
+Category: Astrology
+Question: Which date starts the astrological year?
+Answer: March 21
+Regexp: (Mar(ch)? 21|21(st)? (of )?Mar|21[./]3|3[./]21)
+
+Category: Astronomy
+Question: At the equator, what is the brightest star in the night sky?
+Answer: Sirius
+
+Category: Astronomy
+Question: Excluding the sun, what star is closest to the earth?
+Answer: Proxima Centauri (aka Alpha Centauri)
+Regexp: (Proxima|Alpha) Centauri
+
+Category: Astronomy
+Question: How many moons does Mercury have?
+Answer: none
+Regexp: (none|null|zero|0)
+
+Category: Astronomy
+Question: In which constellation would you look to find the center of The Milky Way?
+Answer: Sagittarius
+
+Category: Astronomy
+Question: Mercury's period of orbit takes how many earth days?
+Answer: eighty eight
+Regexp: (eighty[- ]eight|88)
+
+Category: Astronomy
+Question: On which planet are the craters Brahms and Liszt?
+Answer: Mercury
+
+Category: Astronomy
+Question: Phobos and Deimos are the moons of which planet?
+Answer: Mars
+
+Category: Astronomy
+Question: The four Galilean moons of Jupiter are: Callisto, Io, Ganymede, and _________
+Answer: Europa
+
+Category: Astronomy
+Question: This astronomer had a metal nose
+Answer: Tycho #Brahe#
+
+Category: Astronomy
+Question: This moon is our solar system's most cratered satellite:
+Answer: Callisto
+
+Category: Astronomy
+Question: What do scientists predict will happen when the universe ends?
+Answer: The Big Crunch
+Regexp: (The )?Big Crunch
+
+Category: Astronomy
+Question: What is the sixth planet from our sun?
+Answer: Saturn
+
+Category: Astronomy
+Question: What is the sixth planet from our sun?
+Answer: Saturn
+
+Category: Astronomy
+Question: Where are the 4 major moons of Jupiter discovered by?
+Answer: Galileo
+
+Category: Astronomy
+Question: Which astronomer first observed 4 moons of Jupiter in 1610?
+Answer: #Galileo# Galilei
+
+Category: Astronomy
+Question: Which moon is the largest satellite in our solar system?
+Answer: Ganymede
+
+Category: Astronomy
+Question: Which moon is the second largest satellite in our solar system?
+Answer: Titan
+
+Category: Astronomy
+Question: Which of Neptune's moons is the biggest?
+Answer: Triton
+
+Category: Astronomy
+Question: Who discovered Uranus?
+Answer: Friedrich Wilhelm Herschel
+Regexp: (wilhelm|william) herschel
+
+Category: Astrophysics
+Question: What is the heaviest element that can be formed by regular fusion reactions in the core of a star?
+Answer: iron
+
+Category: BANANAS
+Question: A cluster or bunch of bananas is called a ?
+Answer: hand
+
+Category: BANANAS
+Question: Individual bananas are called ?
+Answer: fingers
+
+Category: Banking
+Question: What was the first credit card called?
+Answer: DinerŽs Club
+
+Category: Beverages
+Question: This drink is made from espresso coffee, steamed milk and chocolate.
+Answer: Mocha
+
+Category: Bibile
+Question: What 'S' was a king of israel who was famous for his wisdom?
+Answer: Solomon
+
+Category: Bible
+Question: How many animals of each kind did Moses take onto the ark?
+Answer: #None# (It Was Noah Not Moses)
+Regexp: (0|None|Nill|Zero)
+
+Category: Bible
+Question: What is the holy cup of Christ called?
+Answer: Holy Grail
+Regexp: (The )?Holy Grail
+
+Category: Big American Things
+Question: The first skyscraper in the United States was built in which city?
+Answer: Chicago
+
+Category: Biology
+Question: The latin word for lips is:
+Answer: labia
+
+Category: Biology
+Question: This cell organelle is responsible for protein production?
+Answer: ribosome
+
+Category: Biology
+Question: What chemical compound causes pain in muscles after exercise?
+Answer: lactic acid
+
+Category: Birds and Countries
+Question: The national bird of India is the?
+Answer: Peacock
+
+Category: Birthstones
+Question: What is the birthstone for February?
+Answer: Amethyst
+
+Category: Body
+Question: What is the name of the body part that separates the abdomen from the thorax?
+Answer: Diaphragm
+
+Category: Botany
+Question: Linen is obtained from the fibers of what plant?
+Answer: flax
+
+Category: Botany
+Question: The leaves of the tomato plant are poisonous, they contain ________
+Answer: strychnine
+
+Category: Botany
+Question: This plant has leaves with delicate trigger hairs, allowing it to sense and trap insects.
+Answer: venus flytrap
+
+Category: Botany
+Question: This spikey succulent, native of Africa, is often an additive in creams and lotions.
+Answer: aloe vera
+
+Category: Botany
+Question: What gives leaves their colour ?
+Answer: Chlorophyll
+
+Category: Botany
+Question: What is the term for a tree which sheds its foliage at the end of the growing season?
+Answer: deciduous
+
+Category: Botany
+Question: What is the term for the group of plants that catch and digest insects?
+Answer: carnivorous
+
+Category: Business
+Question: This brand boasts 57 varieties?
+Answer: Heinz
+
+Category: Cartoon Trivia
+Question: Fat Albert and friends was created by ...... ?
+Answer: Bill #Cosby#
+
+Category: Cartoon Trivia
+Question: Tarzan had a chimpanzee, what was his name?
+Answer: Cheetah
+
+Category: Cartoon Trivia
+Question: What is Peter Parker's secret identity?
+Answer: Spiderman
+Regexp: spider ?man
+
+Category: Cartoon Trivia
+Question: What is the name of Yogi Bear's best freind
+Answer: Boo Boo
+
+Category: Cartoon Trivia
+Question: What was the name of Barney and Betty Rubble's son?
+Answer: Bam Bam
+
+Category: Cartoons
+Question: Mel Blanc, the voice of Bugs Bunny, was allergic to what?
+Answer: carrots
+Regexp: carrot'?s
+
+Category: Catroons
+Question: Mickey Mouse is known as what in Italy?
+Answer: Topolino
+
+Category: Ceremonies
+Question: After how many years marriage do you celebrate your emerald wedding anniversary
+Answer: 55
+Regexp: (55|fifty[ -]?five)
+
+Category: Chemistry
+Question: Ascorbic acid is commonly reffered to as Vitamin - ?
+Answer: C
+
+Category: Chemistry
+Question: Chemical Element Pa?
+Answer: Protactinium
+
+Category: Chemistry
+Question: Coal is predominantly made up of this element.
+Answer: carbon
+
+Category: Chemistry
+Question: Electrum is a natural alloy of gold and what other metal?
+Answer: silver
+
+Category: Chemistry
+Question: He founded our modern periodic table. Surname only?
+Answer: Mendeleev
+
+Category: Chemistry
+Question: In organic chemistry nomenclature, the prefix "meth" means how many atoms of carbon?
+Answer: one
+Regexp: (one|1)
+
+Category: Chemistry
+Question: Peanuts are one of the ingredients of?
+Answer: Dynamite
+
+Category: Chemistry
+Question: The atomic weights in the periodic table are stated in proportion to the weight of what element, with atomic number 6?
+Answer: carbon
+
+Category: Chemistry
+Question: The chemical compound sodium chloride is often sprinkled on food before ingestion. What is it's common name?
+Answer: salt
+
+Category: Chemistry
+Question: This Latin word meaning "iron" is the reason for iron's modern day chemical symbol (Fe).
+Answer: ferrum
+
+Category: Chemistry
+Question: What chemical element gets is name from the greek word meaning 'stranger'?
+Answer: Xenon
+
+Category: Chemistry
+Question: What element is represented by the symbol W?
+Answer: tungsten
+
+Category: Chemistry
+Question: What foul smelling compound is commonly known as rotten egg gas?
+Answer: hydrogen sulphide
+Regexp: hydrogen sul(f|ph)ide
+
+Category: Chemistry
+Question: What is the chemical element Pa?
+Answer: Protactinium
+
+Category: Chemistry
+Question: What is the chemical symbol for californium?
+Answer: Cf
+
+Category: Chemistry
+Question: What is the chemical symbol for curium?
+Answer: Cm
+
+Category: Chemistry
+Question: What is the chemical symbol for einsteinium?
+Answer: Es
+
+Category: Chemistry
+Question: What is the chemical symbol for lead?
+Answer: Pb
+
+Category: Chemistry
+Question: What is the chemical symbol for mercury?
+Answer: Hg
+
+Category: Chemistry
+Question: What is the chemical symbol for radium?
+Answer: Ra
+
+Category: Chemistry
+Question: What is the chemical symbol for radon?
+Answer: Rn
+
+Category: Chemistry
+Question: What is the chemical symbol for tungsten?
+Answer: W
+
+Category: Chemistry
+Question: What is the heaviest of the naturally occuring Noble gases?
+Answer: Radon
+
+Category: Chemistry
+Question: What is the modern name for Plumbum?
+Answer: lead
+
+Category: Chemistry
+Question: What is the most reactive element?
+Answer: fluorine
+
+Category: Chemistry
+Question: What is the symbol for Iron?
+Answer: Fe
+
+Category: Chemistry
+Question: Whats the chemical symbol for Helium ?
+Answer: He
+
+Category: Chemistry
+Question: When traces of a calcium compound are held in a bunsen flame, the colour of the flame changes to ...?
+Answer: red
+
+Category: Chemistry
+Question: Which Russian chemist (1834-1907) founded our modern periodic table?
+Answer: Dmitry Ivanovich #Mendeleyev#
+
+Category: Chemistry
+Question: Which chemical element is represented by the symbol Pa?
+Answer: protactinium
+
+Category: Chemistry
+Question: Which chemical element was foremerly known as the latin "Kalium", hence bears the symbol "K"?
+Answer: potassium
+
+Category: Chemistry
+Question: Which isotope of carbon is used for dating (give number) ?
+Answer: 14
+Regexp: (fourteen|14)
+
+Category: Chemistry
+Question: Which substance has the chemical formula  H3PO4?
+Answer: phosphoric acid
+
+Category: Chemistry
+Question: Which substance has the chemical formula H2SO4?
+Answer: sulfuric acid
+Regexp: Sul[ph|f]uric acid
+
+Category: Chemistry
+Question: Which substance has the chemical formula HCl?
+Answer: hydrochloric acid
+
+Category: Chemistry
+Question: Which substance has the chemical formula HNO3?
+Answer: Nitric Acid
+
+Category: Chemistry
+Question: Which substance has the chemical formula NaOH?
+Answer: Sodium Hydroxide
+
+Category: Church
+Question: According to popular belief brides walk to the what in the church? (not the aisle)
+Answer: The nave of the church
+
+Category: Clichés
+Question: The pen is mightier then the ......
+Answer: sword
+
+Category: Cocktails
+Question: To make Drambuie, you add some honey to what type of whiskey?
+Answer: Scotch
+
+Category: Cocktails
+Question: Vodka or gin, ____ juice and sugar make a gimlet.
+Answer: lime
+
+Category: Cold things
+Question: What percentage of Antarctica is ice?
+Answer: ninty eight
+Regexp: (98|Ninty eight)
+
+Category: Common Terms
+Question: A meaningless distraction is a ... herring.
+Answer: red
+
+Category: Common Terms
+Question: How many is a baker's dozen?
+Answer: thirteen
+Regexp: (thirteen|13)
+
+Category: Common Terms
+Question: What is often referred to as "the oldest profession"?
+Answer: prostitution
+
+Category: Computer
+Question: What does DMA stand for?
+Answer: Direct Memory Access
+
+Category: Computer
+Question: What does the acronym COBOL stand for?
+Answer: Common Business Oriented Language
+
+Category: Computers
+Question: Linux is a clone of what operating system?
+Answer: UNIX
+Regexp: U.?N.?I.?X.?
+
+Category: Computers
+Question: What does ASCII stand for?
+Answer: american Standard code for information interchange
+
+Category: Computers
+Question: What does CR-ROM stand for?
+Answer: Compact Disk Read Only Memory
+Regexp: Compact Disk( |-)Read Only Memory
+
+Category: Computers
+Question: What does bit stands for?
+Answer: binary digit
+
+Category: Conflict
+Question: At the outbreak of WWI what country's airforce consisted of only 50 men?
+Answer: United States
+Regexp: (United States|U.?S.?A?.?|America)
+
+Category: Corporations
+Question: Who owns Weight Watchers?
+Answer: #Heinz# Foods
+
+Category: Cosmology
+Question: What term is given to the center of a black hole?
+Answer: singularity
+
+Category: Cosmology
+Question: Who wrote 'A Bory: Geography
+Question: In which country would you find Angkor Wat?
+Answer: Cambodia
+
+Category: Geography
+Question: In which state is the source of the Mississippi River?
+Answer: Minnesota
+
+Category: Geography
+Question: Jakarta is located on which Indonesian island?
+Answer: Java
+
+Category: Geography
+Question: Located above and just below the Arctic Circle, this region became an official territory of Canada in April 1999.
+Answer: Nunavut
+
+Category: Geography
+Question: Monaco has the same flag as what other country?
+Answer: Indonesia
+
+Category: Geography
+Question: Name the highest mountain in Africa.
+Answer: Mt. #Kilimanjaro#
+
+Category: Geography
+Question: Name the three baltic countries?
+Answer: Estonia, Latvia, Lithuania
+
+Category: Geography
+Question: Near what major city is Mount Fuji?
+Answer: Tokyo
+
+Category: Geography
+Question: The "Old City" of this holy location is divided into four quarters  a Christian quarter, a Muslim Quarter, a Jewish Quarter, and an Armenian Quarter.
+Answer: Jerusalem
+
+Category: Geography
+Question: The Andaman Islands belong to which country?
+Answer: india
+
+Category: Geography
+Question: The City of Fireze is better known is english as what?
+Answer: Florence
+
+Category: Geography
+Question: The Indus River flows through which country?
+Answer: Pakistan
+
+Category: Geography
+Question: The Palk Strait runs between which two countries?
+Answer: India and Sri Lanka
+Regexp: (India (and |& )Sri Lanka|Sri Lanka (and |& )India)
+
+Category: Geography
+Question: The island of Hispaniola consists of the Dominican Republic and this country.
+Answer: Haiti
+
+Category: Geography
+Question: This Moslem republic in asia was formerly part of India.
+Answer: Pakistan
+
+Category: Geography
+Question: This country is divided into two parts: Sabah and Sarawak on the island of Borneo, and a peninsula north of Singapore.
+Answer: Malaysia
+
+Category: Geography
+Question: This coutry holds the distinction of being the least densely populated in the world.
+Answer: Mongolia
+
+Category: Geography
+Question: This is the longest mountain chain in the world.
+Answer: Andes
+
+Category: Geography
+Question: This mountain, found in the California Cascades, is famous for it's twin peaks?
+Answer: Mount Shasta
+
+Category: Geography
+Question: This mountain, found in the California Cascades, is famous for it's twin peaks?
+Answer: Mount Shasta
+
+Category: Geography
+Question: Vilnius is the capital of which country?
+Answer: Lithuania
+
+Category: Geography
+Question: What 'I' was once Mesopotamia?
+Answer: Iraq
+
+Category: Geography
+Question: What 2 countries have square flags?
+Answer: Switzerland and the Vatican
+
+Category: Geography
+Question: What American state has a Thames river?
+Answer: Connecticut
+
+Category: Geography
+Question: What US Citys name means 'straits' or 'channel'?
+Answer: Detroit
+
+Category: Geography
+Question: What US state has the most tornadoes on average?
+Answer: Texas
+
+Category: Geography
+Question: What color are French Letter Boxes?
+Answer: yellow
+
+Category: Geography
+Question: What country has a birth rate of 0?
+Answer: The Vatican City
+
+Category: Geography
+Question: What country has the world's most southerly city?
+Answer: Chile
+
+Category: Geography
+Question: What is South America's highest peak in the Andes, Argentina?
+Answer: Aconcagua
+
+Category: Geography
+Question: What is capital of Lithuania?
+Answer: Vilnius
+
+Category: Geography
+Question: What is capital of Ukraine?
+Answer: Kiev
+
+Category: Geography
+Question: What is the capital city of New Zealand?
+Answer: Wellington
+
+Category: Geography
+Question: What is the capital of Brazil?
+Answer: Brasilia
+
+Category: Geography
+Question: What is the capital of Croatia?
+Answer: Zagreb
+
+Category: Geography
+Question: What is the capital of Estonia?
+Answer: Tallin
+
+Category: Geography
+Question: What is the capital of Guam?
+Answer: Agana
+
+Category: Geography
+Question: What is the capital of Hawaii?
+Answer: Honolulu
+
+Category: Geography
+Question: What is the capital of Honduras?
+Answer: Tegucigalpa
+
+Category: Geography
+Question: What is the capital of Madagascar?
+Answer: Antananarivo
+
+Category: Geography
+Question: What is the capital of Moldova?
+Answer: Kishinev
+
+Category: Geography
+Question: What is the capital of Nicaragua?
+Answer: Managua
+
+Category: Geography
+Question: What is the capital of Wales?
+Answer: Cardiff
+
+Category: Geography
+Question: What is the capital of Wales??
+Answer: Cardiff
+
+Category: Geography
+Question: What is the capital of the Italian province Lazio?
+Answer: Rome
+
+Category: Geography
+Question: What is the capital of the overseas department and administrative region of France, Réunion?
+Answer: Saint-Denis
+Regexp: (saint|st|st\.)[- ]denis
+
+Category: Geography
+Question: What is the capitol of Iceland?
+Answer: Reykjavik
+
+Category: Geography
+Question: What is the highest mountain in Europe?
+Answer: Mont Blanc
+
+Category: Geography
+Question: What is the highest mountain in the Appalachian range?
+Answer: Mt. Mitchell
+Regexp: (mt|mt\.|mount) mitchell
+
+Category: Geography
+Question: What is the highest mountain in the world?
+Answer: Mount Everest
+Regexp: (Mount )?Everest
+
+Category: Geography
+Question: What is the highest point in South America?
+Answer: Aconcagua
+
+Category: Geography
+Question: What is the highest waterfall in the USA?
+Answer: Yosemite
+
+Category: Geography
+Question: What is the largest island in the Caribbean?
+Answer: Cuba
+
+Category: Geography
+Question: What is the largest island in the East Indies?
+Answer: Borneo
+
+Category: Geography
+Question: What is the largest island in the Indian Ocean?
+Answer: Madagascar
+
+Category: Geography
+Question: What is the largest island in the Mediterranean?
+Answer: Sicily
+
+Category: Geography
+Question: What is the largest island in the Philippines?
+Answer: Luzon
+
+Category: Geography
+Question: What is the largest island in the world?
+Answer: Greenland
+
+Category: Geography
+Question: What is the largest lake in Europe?
+Answer: Lake #Lagoda#
+
+Category: Geography
+Question: What is the largest natural lake found in Africa?
+Answer: Lake Victoria
+
+Category: Geography
+Question: What is the largest of the pyramids in Egypt?
+Answer: Cheops
+
+Category: Geography
+Question: What is the longest mountain range in the world?
+Answer: Andes
+
+Category: Geography
+Question: What is the longest river in Australia?
+Answer: Darling
+
+Category: Geography
+Question: What is the name of the famous large coral reef located off the coast of northeastern Australia?
+Answer: Great Barrier Reef
+
+Category: Geography
+Question: What is the name of the large natural landmark in northern Australia also known as Uluru?
+Answer: Ayers Rock
+Regexp: Ayer'?s Rock
+
+Category: Geography
+Question: What is the name of the mountain chain separating most of Spain from France?
+Answer: Pyrenees
+
+Category: Geography
+Question: What is the only country in the world whose name starts with 'O'?
+Answer: Oman
+
+Category: Geography
+Question: What is the second highest peak in Africa?
+Answer: Mt. Kenya
+Regexp: (mt|mt\.|mount) kenya
+
+Category: Geography
+Question: What is the worlds longest concrete dam?
+Answer: #Grand Coulee# Dam
+
+Category: Geography
+Question: What two US states are rectangular?
+Answer: Colorado and Wyoming
+
+Category: Geography
+Question: What was the former name of Thailand?
+Answer: Siam
+
+Category: Geography
+Question: What was the hightest mountain in the world before the discovery of everest?
+Answer: Mount Everest
+
+Category: Geography
+Question: What's the capital of Poland?
+Answer: Warsaw
+
+Category: Geography
+Question: Where is Dogger Bank?
+Answer: The North Sea
+
+Category: Geography
+Question: Where is the original London Bridge located?
+Answer: Lake Havasu,
+
+Category: Geography
+Question: Where is the tallest building in the world?
+Answer: #Dubai#, United Arab Emirates
+
+Category: Geography
+Question: Which city is home to the 4th largest pyramid in the world?
+Answer: Las Vegas
+
+Category: Geography
+Question: Which is the only South East Asian country that is a member of the British Commonwealth?
+Answer: malaysia
+
+Category: Geography
+Question: Which is the only land-locked country in South East Asia?
+Answer: Laos
+
+Category: Geography
+Question: Which river produces the most sediment?
+Answer: #Yellow# River
+
+Category: Geography
+Question: Which sea is located between Australia and New Zealand?
+Answer: Tasman
+
+Category: Geography
+Question: Who is regarded as the most influential monarch of Russian Romanov Dynasty?
+Answer: Peter I
+Regexp: Peter the Great
+
+Category: Geography
+Question: Wracked by heavy monsoon rains 3 to 4 months of the year, this is the wettest and most flood-prone nation in Asia.
+Answer: Bangladesh
+
+Category: Geography
+Question: if you climbed the Euromast what country would you be in?
+Answer: Rotterdam
+
+Category: Geography
+Question: in what country do people speak the Language they call Nihongo?
+Answer: Japan
+
+Category: Geography
+Question: what country has the highest per capita tea consumption?
+Answer: ireland
+
+Category: Geography
+Question: what country has the oldest constitution that still exists?
+Answer: America
+
+Category: Geography
+Question: what river separates the city of Florence?
+Answer: Arno
+
+Category: Geograpy
+Question: What is the second highest peak in Mexico?
+Answer: Popocatepetl
+
+Category: Geometry
+Question: A line that touches a circle at only one point is called a ....... ?
+Answer: tangent
+
+Category: Geometry
+Question: A line that touches a circle at two points is called a .....
+Answer: chord
+
+Category: Geometry
+Question: How many degrees in an interior angles of an equilateral triangle?
+Answer: sixty
+Regexp: (sixty|60)
+
+Category: Geometry
+Question: How many faces does a dodecahedron have?
+Answer: twelve
+Regexp: (twelve|12)
+
+Category: Geometry
+Question: The longest side in a right-angled triangle is called the .......
+Answer: hypotenuse
+
+Category: Geometry
+Question: The volume of which solid is given by the formula 4/3(pi)r^3?
+Answer: sphere
+
+Category: Geometry
+Question: What is the name given to a quadrilateral with one, and only one, pair of sides parallel to each other?
+Answer: trapezium
+
+Category: Greek words
+Question: "deinos" and "sauros" roughly translate to?
+Answer: terrible lizard
+
+Category: History
+Question: After the fall of the iron curtain, Russian leader Mikhail Gorbachev introduced a period of restructuring known as ________.
+Answer: Perestroika
+
+Category: History
+Question: After the fall of the manchu dynasty, there existed three political parties in china: The KMT, Nationalists and The ...... ?
+Answer: #Communist#s
+
+Category: History
+Question: Also known as the 'Isle of Apples', Christ and Joseph of Aramathea travelled here in ancient times.
+Answer: Avalon
+
+Category: History
+Question: Elizabeth I was the daughter of which king?
+Answer: Henry VIII
+Regexp: henry (the )?(8th|VIII|eighth)
+
+Category: History
+Question: Gangster Al Capone, boss of the Chicago underworld, was finally gaoled for 11 years for what crime?
+Answer: tax evasion
+
+Category: History
+Question: How many presidents of the United States fought in the Civil War?
+Answer: six
+Regexp: (six|6)
+
+Category: History
+Question: In 1959, Tibet was invaded by which country?
+Answer: China
+
+Category: History
+Question: In what war did the jet fighters first battle each other?
+Answer: The Korean War
+Regexp: (the )?korean?( war)?
+
+Category: History
+Question: In which English town was William Shakespeare born?
+Answer: #Stratford#-Upon-Avon
+
+Category: History
+Question: In which war did Florence Nightingale earn her reputation ?
+Answer: #Crimean# War
+
+Category: History
+Question: Near which Belarus City did the biggest ever tank battle take place during WWII?
+Answer: Kursk
+
+Category: History
+Question: Queen Cleopatra proclaimed herself to be which Egyptian goddess?
+Answer: Isis
+
+Category: History
+Question: Ritchie Valens and The Big Bopper were killed in a plane crash in 1959. Which other famous singer was killed in that crash?
+Answer: Buddy Holly
+
+Category: History
+Question: Rorke's Drift was a battle in which war?
+Answer: The Zulu War
+
+Category: History
+Question: Sir Stamford Raffles founded which minor Asian nation?
+Answer: Singapore
+
+Category: History
+Question: The American M4 tank is better known as what?
+Answer: The Sherman tank
+
+Category: History
+Question: The Greek army under Leonides was annihilated here by Persians in 480BC.
+Answer: Thermopylae
+
+Category: History
+Question: The _____ universe was replaced by the Copernican universe.
+Answer: Ptolemic
+
+Category: History
+Question: The birthplace of Napoleon, also the capital of Corsica, is?
+Answer: Ajaccio
+
+Category: History
+Question: The massacre at Kent State occurred as students protested the bombing of Cambodia and the _____ war.
+Answer: Vietnam
+
+Category: History
+Question: The three buildings of the Acropolis are the Propylaea, the Erectheum, and the _________.
+Answer: Parthenon
+
+Category: History
+Question: These fighters always began a bout by saying, "Hail Emperor, those about to die salute you."?
+Answer: gladiators
+Regexp: gladiator'?s
+
+Category: History
+Question: This Chinese dynasty lasted from 1368 to 1644.
+Answer: Ming
+
+Category: History
+Question: This European war was named after a peninsula between the Black sea and the sea of Azov?
+Answer: Crimean War
+
+Category: History
+Question: This European war was named after a peninsula between the Black sea and the sea of Azov?
+Answer: Crimean War
+
+Category: History
+Question: This U.S. President suffered from polio during WWII.
+Answer: Franklin D #Roosevelt#
+
+Category: History
+Question: What American city was called New Amsterdam in the early 17th century?
+Answer: New York
+
+Category: History
+Question: What Venetian traveler and explorer landed in China and reached Kublai Khan's court in 1275?
+Answer: Marco Polo
+
+Category: History
+Question: What city holds the distinction of opening the world's first public library in 1747?
+Answer: Warsaw, Poland
+
+Category: History
+Question: What colour was added to the French flag during the French revolution?
+Answer: white
+
+Category: History
+Question: What did Anne Boleyn have three of?
+Answer: breasts
+Regexp: brest'?s
+
+Category: History
+Question: What did Julius Caesar cross to signal a revolt against the senate?
+Answer: rubikon
+
+Category: History
+Question: What did Napoleon have built to commemorate his victories?
+Answer: Arc de Triomphe
+
+Category: History
+Question: What do historians call the journey made by Mao to the Northwest of China after Chiang Kai-Shek had driven his forces out of the South and East?
+Answer: The Long March
+Regexp: Long March
+
+Category: History
+Question: What is the former name of Sri Lanka?
+Answer: Ceylon
+
+Category: History
+Question: What is the name of the German Officer who lived and died in Madrid and rescued Mussolini?
+Answer: Otto Skorzeny
+
+Category: History
+Question: What treaty, signed in 1713, ended the War of the Spanish Succession?
+Answer: Treaty of #Utrecht#
+
+Category: History
+Question: What was Europe's first super-high-speed passenger train powered by?
+Answer: electricity
+
+Category: History
+Question: What was Operation Sea Lion in WWII?
+Answer: The Invasion of Britian
+
+Category: History
+Question: What was name of the Titanic's sister ship?
+Answer: Lucitania
+Regexp: Lu[sc]itania
+
+Category: History
+Question: What was the initial capital of USSR?
+Answer: Leningrad
+
+Category: History
+Question: What was the last Port of call for the Titanic?
+Answer: Queenstown
+
+Category: History
+Question: What was the most Eastern country in Alexander The Great's command at his peak?
+Answer: India
+
+Category: History
+Question: What was the name given to the atom bomb that was dropped on Hiroshima?
+Answer: Fat Man
+
+Category: History
+Question: What were 'Little Boy' and 'Fat Man'?
+Answer: Atom Bombs
+
+Category: History
+Question: Where did the battle of Waterloo take place?
+Answer: Belgium
+
+Category: History
+Question: Where did the most famous encirclement of the Nazi troops during WWII take place?
+Answer: Stalingrad
+
+Category: History
+Question: Where is the infamous Lubjanka prison?
+Answer: Moscow
+
+Category: History
+Question: Which English King issued the Magna Carta in 1215?
+Answer: King #John#
+
+Category: History
+Question: Which country ruled Cambodia immediately before WWII?
+Answer: France
+
+Category: History
+Question: Which island was Napoleon from?
+Answer: corsica
+
+Category: History
+Question: Which poisonous concoction was Socrates given to drink to carry out his death sentence?
+Answer: hemlock
+
+Category: History
+Question: Which police-dog was one of Stalin's favourites?
+Answer: Berya
+
+Category: History
+Question: Who denounced Stalin?
+Answer: Nikita
+
+Category: History
+Question: Who did Henry VIII marry when he was 18?
+Answer: Catharine of Aragon
+
+Category: History
+Question: Who discovered the tomb of Tutankhamen?
+Answer: Howard Carter
+
+Category: History
+Question: Who invented the record player ?
+Answer: Thomas Alva Edison
+
+Category: History
+Question: Who is Prince Vladimir Tepes better known as?
+Answer: Dracula
+
+Category: History
+Question: Who outlawed gladiator sports in Rome?
+Answer: Caesar
+Regexp: (Julius )?Caesar
+
+Category: History
+Question: Who ruled England at the time of Shakespeare?
+Answer: Elizabeth I
+Regexp: Elizabeth (I|(the )?(1st|first))
+
+Category: History
+Question: Who shot President James Garfield?
+Answer: Charles #Guiteau#
+
+Category: History
+Question: Who was Henry VIII's second wife?
+Answer: Anne Boleyn
+
+Category: History
+Question: Who was the Taj Mahal built in memory of?
+Answer: Mumtaj Mahal
+
+Category: History
+Question: Who was the father of Elizabeth I?
+Answer: Henry VIII
+Regexp: Henry (VIII|(the )?(8th|eighth))
+
+Category: History
+Question: Who was the last American president to sport facial hair?
+Answer: Taft
+
+Category: History
+Question: Who was the man convicted of masterminding the 1969 LaBianca-Tate murders, later to become known as the Helter Skelter killings?
+Answer: Charles #Manson#
+
+Category: History
+Question: Who was the most famous leader of the Carthagenians?
+Answer: Hannibal
+
+Category: History
+Question: Who was the mother of Elizabeth I?
+Answer: Anne Boleyn
+
+Category: History
+Question: Whose army did Admiral Nelson defeat at the battle of Trafalgar?
+Answer: Napoleon
+
+Category: Hobbies
+Question: Which light wood is commonly used for making aeromodels?
+Answer: Balsa
+
+Category: Hollywood
+Question: Who directed "Jurassic Park III?"
+Answer: Joe Johnston
+
+Category: Homonyms
+Question: Drill a hole into/a crude uncouth person (answer in the form of word1/word2)?
+Answer: bore/boor
+
+Category: Homonyms
+Question: Scram!/foot apparel (answer in form of word1/word2)
+Answer: Shoo/Shoe
+
+Category: Homonyms
+Question: To save up as for future use/a vast multitude (answer in the form of word1/word2)?
+Answer: hoard/horde
+
+Category: IRC
+Question: Who wrote mIRC?
+Answer: Khaled Mardam-Bey
+
+Category: Internet
+Question: What does FTP stand for?
+Answer: File Transfer Protocol
+
+Category: Internet
+Question: What does the acronym HTML stand for?
+Answer: Hyper Text Markup Language
+
+Category: Internet
+Question: What is IRC an acronym for?
+Answer: internet relay chat
+
+Category: Inventions
+Question: What did john logie baird invent in 1925?
+Answer: Television
+
+Category: Isms
+Question: Indifference to pleasure of pain; Grrek philosophical system following the teachings of Zeno?
+Answer: Stoicism
+
+Category: Isms
+Question: Speaking of G.B. Shaw, he originally adhered to a form of communism called?
+Answer: fabianism
+
+Category: Isms
+Question: The social and philosophic creedo of Irish playwright George Bernard Shaw is called:
+Answer: shavianism
+
+Category: Juicey
+Question: What was originally called the Chinese gooseberry?
+Answer: kiwi
+
+Category: Language
+Question: How do you say "I Love You" in German?
+Answer: Ich liebe Dich
+
+Category: Language
+Question: What does the Greek root word 'chrom' mean?
+Answer: color
+Regexp: colou?r
+
+Category: Language
+Question: What is the first letter in the Greek alphabet?
+Answer: Alpha
+
+Category: Language
+Question: What is the last letter in the Greek alphabet?
+Answer: Omega
+
+Category: Language
+Question: What is the official language of Senegal?
+Answer: French
+
+Category: Language
+Question: Which is the only english word that contains all the vowels in alphabetical order?
+Answer: facetious
+
+Category: Languages
+Question: From which language does the term 'Mayday' come?
+Answer: French
+
+Category: Languages
+Question: The Scots call it 'shinty' - what do Canadians and Americans call it?
+Answer: hockey
+
+Category: Languages
+Question: Which word means "profound boredom" in both french and english?
+Answer: ennui
+
+Category: Legal Terms
+Question: This defense is also know as compulsion by threat.
+Answer: duress
+
+Category: Legends
+Question: What was the name of the Lady Godiva's horse?
+Answer: Aethenoth
+
+Category: Literature
+Question: "Now is the winter of our discontent" is a line from which Shakespearian play?
+Answer: Richard III
+Regexp: Richard (the )?(III|3rd|third)
+
+Category: Literature
+Question: According To "The Hitchhikers Guide To The Galaxy" what number is the answer to everything?
+Answer: Forty Two
+Regexp: (42|Forty Two)
+
+Category: Literature
+Question: Author of "The Lighthouse" and "Eminent Victorians"?
+Answer: Virginia Woolf
+
+Category: Literature
+Question: Author of such works as Gravity's Rainbow, V, The Crying of Lot 49 and most recently, Mason & Dixon?
+Answer: Thomas Pynchon
+Regexp: (Thomas )?Pynchon
+
+Category: Literature
+Question: Bob Kane created who?
+Answer: Batman
+
+Category: Literature
+Question: Faulkner penned this book with 4 distinctive sections: the Benjy section, Quentin's section, Jason and then Dilsey's sections.
+Answer: The Sound and the Fury
+
+Category: Literature
+Question: From which of Shakespeare's plays is this line: "All the world's a stage..."
+Answer: As You Like It
+
+Category: Literature
+Question: He penned the founding novel of the utopian genre, "Utopia."?
+Answer: Sir Thomas More
+
+Category: Literature
+Question: He wrote Ulysses, Giacomo Joyce, Dubliners and Finnegans Wake, among others.
+Answer: James Joyce
+
+Category: Literature
+Question: His many Romantic odes include 'Ode to Melancholy' and 'Ode to a Graecian Urn'
+Answer: John Keats
+
+Category: Literature
+Question: His many Romantic odes include Ode to Melancholy and Ode to a Graecian Urn?
+Answer: Keats
+
+Category: Literature
+Question: In HG Wells "The Time Machine," two races of the future are the child-like Eloi, and the underground monsters called the ____?
+Answer: Morlocks
+
+Category: Literature
+Question: In What book would you find a Hefalump?
+Answer: Winnie the Pooh
+
+Category: Literature
+Question: Name the author of 'The Catcher in the Rye'
+Answer: J.D. #Salinger#
+
+Category: Literature
+Question: Name the author of his famous and only novel 'Doctor Zhivago', which presents a panoramic view of Russian society at the time of the 1917 Revolution.
+Answer: Boris Pasternak
+
+Category: Literature
+Question: Sherlock Holmes lived at 221b ..... street?
+Answer: Baker
+
+Category: Literature
+Question: The ____ ____ school of poetry includes poets such as Frank O'Hara, John Ashbery and Kenneth Koch
+Answer: New York
+
+Category: Literature
+Question: The ____ generation included such authors as Jack Kerouac, William S. Burroughs and Allen Ginsburg.
+Answer: Beat
+
+Category: Literature
+Question: The fallacy of personifying inanimate objects, often in bad taste?
+Answer: pathetic fallacy
+
+Category: Literature
+Question: The two races in HG Well's "The Time Machine" are the child-like Eloi and the subterannean ______?
+Answer: Morlocks
+
+Category: Literature
+Question: This Romantic poet and husband to Mary Shelley drowned in a boating accident.
+Answer: Percy Bysshe Shelley
+
+Category: Literature
+Question: This Romantic poet and wife of Mary Shelley drowned in a boating accident?
+Answer: Percy Bysshe Shelley
+
+Category: Literature
+Question: This book, Oscar Wilde's only novel, was used as evidence in his sodomy trial?
+Answer: The Picture of Dorian Gray
+Regexp: (The )?Picture of Dorian Gray
+
+Category: Literature
+Question: This early American statesman and inventor wrote the book, "Fart proudly"?
+Answer: Benjamin Franklin
+
+Category: Literature
+Question: This is the choice and arrangement of words and phrases in a literary work. It is the vocabulary that the author, poet or playwright uses to create style and effect in a piece of writing?
+Answer: diction
+
+Category: Literature
+Question: What Irish playwright and author, wrote "The Importance of Being Ernest" and "A Picture of Dorian Grey" among others?
+Answer: Oscar Wilde
+
+Category: Literature
+Question: What Was Sherlock Holmes' 7% solution in 'The Sign of Four'?
+Answer: Cocaine
+
+Category: Literature
+Question: What famous character did Edgar Rice Burroughs create?
+Answer: Tarzan
+
+Category: Literature
+Question: What famous character did Edgar Rice Burroughs create?
+Answer: Tarzan
+
+Category: Literature
+Question: What is an Icelandic epic called?
+Answer: saga
+
+Category: Literature
+Question: What is the name of Hamlet's tragic admirer?
+Answer: Ophelia
+
+Category: Literature
+Question: What is the name of the main character in Homer's Odyssey?
+Answer: Odysseus
+
+Category: Literature
+Question: What is the opposite of an utopia?
+Answer: dystopia
+
+Category: Literature
+Question: What play by Shakespeare features the following characters: Cornwall, Gloucester, Regan, and Goneril?
+Answer: King Lear
+
+Category: Literature
+Question: What was Dante's last name?
+Answer: Alighieri
+
+Category: Literature
+Question: What was sherlock holmes most famous novel?
+Answer: The Hound of The Baskervilles
+
+Category: Literature
+Question: What was the sequel to Louisa May Alcott's "Little Women"?
+Answer: Little Men
+
+Category: Literature
+Question: Which Shakesperian play features the line "Now is the winter of our discontent"?
+Answer: Richard III
+Regexp: Richard (III|the (third|3rd))
+
+Category: Literature
+Question: Which US author penned the novels "Of Mice and Men" and "East Of Eden"?
+Answer: John Steinbeck
+
+Category: Literature
+Question: Which US dramatist was once married to Marylin Monroe and penned the plays "Death Of A Salesman" and "The Crucible"?
+Answer: Arthur Miller
+
+Category: Literature
+Question: Which poet, in his "Elegy Written in a Country Churchyard" told us that "Full many a flower is born to blush unseen / And waste its sweetnes on the desert air."?
+Answer: Thomas Gray
+Regexp: (Thomas )?Gray
+
+Category: Literature
+Question: Who created Winnie the Pooh?
+Answer: A. A. #Milne#
+
+Category: Literature
+Question: Who is karen Blixen better known as?
+Answer: Isaak Dinesen
+
+Category: Literature
+Question: Who is the author of "Brave New World" ?
+Answer: Aldous #Huxley#
+
+Category: Literature
+Question: Who is the author of "Harry Potter" ?
+Answer: Joan #Rowling#
+
+Category: Literature
+Question: Who is the protagonist of Milton's Paradise Lost?
+Answer: Satan
+
+Category: Literature
+Question: Who writes the discworld novels?
+Answer: Terry Pratchett
+
+Category: Literature
+Question: Who wrote "Animal Farm"?
+Answer: George #Orwell#
+
+Category: Literature
+Question: Who wrote "Ten Little Indians?"
+Answer: Agatha Christie
+
+Category: Literature
+Question: Who wrote "The Rime of the Ancient Mariner?"
+Answer: Samuel Taylor #Coleridge#
+
+Category: Literature
+Question: Who wrote "The count of Monte-Christo"?
+Answer: Dumas
+
+Category: Literature
+Question: Who wrote 'Rendezvous with Rama'?
+Answer: Sir Arthur C. Clarke
+Regexp: (Sir )?Arthur C.? Clarke
+
+Category: Literature
+Question: Who wrote 'The Canterbury Tales'?
+Answer: Geoffrey #Chaucer#
+
+Category: Literature
+Question: Who wrote 'The Great Gatsby'?
+Answer: F. Scott #Fitzgerald#
+
+Category: Literature
+Question: Who wrote 'To Kill A Mockingbird'?
+Answer: Harper Lee
+
+Category: Literature
+Question: Who wrote Great Expectations?
+Answer: Charles #Dickens#
+
+Category: Literature
+Question: Who wrote The Canterbury Tales?
+Answer: Geoffrey Chaucer
+
+Category: Literature
+Question: Who wrote the epic poems, the Iliad and the Odyssey?
+Answer: Homer
+
+Category: Literature
+Question: Who wrote the famous series of Discworld books?
+Answer: Terry Pratchett
+Regexp: (Terry )?Pratchett
+
+Category: Literature
+Question: Who wrote the long religious epic, "Paradise Lost"?
+Answer: John Milton
+
+Category: Literature
+Question: Who wrote the threepenny opera?
+Answer: Bertolt Brecht
+
+Category: Literature:
+Question: What famous character did Edgar Rice Burroughs create?
+Answer: Tarzan
+
+Category: Logic
+Question: If its 4:45PM on Kathmandu what time is it in Madrid?
+Answer: Noon
+
+Category: Magic
+Question: The American Soceity of Magicians has status of being what?
+Answer: The #Largest Magic Organistation#
+
+Category: Mathematics
+Question: 2 + 5 x 6 = ?
+Answer: 32
+
+Category: Mathematics
+Question: 2.7182 is the approximation for which variable used in logarithms?
+Answer: e
+
+Category: Mathematics
+Question: Benoit Mandelbrot discovered what mathematical structures?
+Answer: #fractal#s
+
+Category: Mathematics
+Question: Solve this: 10*3+2?
+Answer: 32
+
+Category: Mathematics
+Question: The first antiderivative of acceleration is:
+Answer: velocity
+
+Category: Mathematics
+Question: What is the name given to a curve that approaches a line, but never quite touches it?
+Answer: asymptote
+
+Category: Mathematics
+Question: What is the name given to the number equal to 10 raised to the power of 100?
+Answer: A "#googol#"
+
+Category: Mathematics
+Question: What is x to the power of zero equal to?
+Answer: one
+Regexp: (one|1)
+
+Category: Maths
+Question: If you count from 1 to 100, how many 7's will you come across?
+Answer: 20
+Regexp: (20|Twenty)
+
+Category: Maths
+Question: What is next in the series 1 8 27 ?? 125 216?
+Answer: 64
+Regexp: (64|Sixty Four)
+
+Category: Medicine
+Question: The sulphate of which metal is used to render the alimentary canal opaque to X-rays (symbol Ba)?
+Answer: barium
+
+Category: Medicine
+Question: This alkaloid extracted from chincona bark, ______ is commonly used in malaria therapy.
+Answer: quinine
+
+Category: Medicine
+Question: This condition characterized by the swelling of the thyroid gland is caused by an iodine deficiency.
+Answer: goitre
+Regexp: (goiter|goitre)
+
+Category: Medicine
+Question: What is hyperglycemia commonly known as ?
+Answer: diabetes
+
+Category: Metals
+Question: What is the main component of Brass and Bronze?
+Answer: Copper
+
+Category: Metals
+Question: What metal do you get from Hematite?
+Answer: iron
+
+Category: Minerals
+Question: The valuable blue form of corundum is called:
+Answer: sapphire
+
+Category: Minerals
+Question: What is the yellow variety of quartz?
+Answer: Citrine
+
+Category: Minerals
+Question: What metal is the major constituent of Rubies ?
+Answer: Aluminium
+
+Category: Modified Vegetables
+Question: In what modified vegetable did Cinderalla travel to the ball in?
+Answer: pumpkin
+
+Category: Money
+Question: What is the largest denomination dollar bill issued?
+Answer: $100
+
+Category: More American stuff
+Question: In the United States at the turn of the century there were how many states (numerical)?
+Answer: forty five
+Regexp: (45|forty five)
+
+Category: Movie Trivia
+Question: How many Oscars did Ben Hur win?
+Answer: eleven
+Regexp: (eleven|11)
+
+Category: Movie Trivia
+Question: John Travolta, Samuel Jackson, Uma Thurman starred in which 1994 Quentin Tarantino film?
+Answer: Pulp Fiction
+
+Category: Movie Trivia
+Question: Richard Strauss' majestic overture "Also Sprach Zarathustra" was the theme music for which Stanley Kubrick film?
+Answer: #2001# : A Space Odyessy
+
+Category: Movie Trivia
+Question: What was the Oscar-winning theme song from "Breakfast at Tiffany's"?
+Answer: Moon River
+
+Category: Movie Trivia
+Question: Who directed the movie "Blade Runner"?
+Answer: Ridley Scott
+
+Category: Movie Trivia
+Question: Who played the first James Bond?
+Answer: Sean Connery
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "Braveheart"?
+Answer: Mel Gibson
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "Castaway"?
+Answer: Tom Hanks
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "Erin Brokovich"?
+Answer: Julia Roberts
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "Mission Impossible"?
+Answer: Tom Cruise
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "Snatch"?
+Answer: Brad Pitt
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "The Mask"?
+Answer: Jim Carrey
+
+Category: Movie Trivia
+Question: Who played the lead in the movie "The Matrix"?
+Answer: Keanu Reeves
+
+Category: Movie Trivia
+Question: Who was the first James Bond?
+Answer: Sean Connery
+
+Category: Movie trivia
+Question: Who directed '2001: A Space Odyssey' and 'A Clockwork Orange'.
+Answer: Stanley Kubrick
+
+Category: Movies
+Question: Before being married to Pamela Anderson what other famous actress was Tommy Lee married to?
+Answer: Heather Locklear
+
+Category: Movies
+Question: He was the voice of draco the dragon in the movie Dragonheart.
+Answer: Sean Connery
+
+Category: Movies
+Question: How many storm troopers were seen in Star Trek?
+Answer: #None# (It Was Star Wars)
+Regexp: (0|None|Nill|Zero)
+
+Category: Movies
+Question: Name the late actor who played Obi-Wan Kenobi in Star Wars?
+Answer: Alec Guiness
+
+Category: Movies
+Question: Orson Wells was nominated for four oscars for which legendary movie?
+Answer: Citizen Kane
+
+Category: Movies
+Question: Rolling Stones first hit was written by what group?
+Answer: The Beatles
+Regexp: (The )?Beatles
+
+Category: Movies
+Question: e
+Question: What is the only other animal besides humans to have unique prints?
+Answer: Koala Bears
+Regexp: Koala Bear'?s?
+
+Category: Nature
+Question: What's the technical name for a three legged frog?
+Answer: Ai
+
+Category: Numbers
+Question: In roman numerals what does the letter M with a Bar over it stand for?
+Answer: One Million
+
+Category: Nursery Rhymes
+Question: Peter Piper picked a peck of what?
+Answer: pickled peppers
+
+Category: Nutrition
+Question: The lack of what vitamin causes beriberi (numbness in the hands and feet)?
+Answer: B1
+
+Category: Optics
+Question: What colour do you get when you mix blue and red together?
+Answer: Purple
+
+Category: Optics
+Question: What colour do you get when you mix blue and yellow together?
+Answer: Green
+
+Category: Palindromes
+Question: Complete the Palindrome: satan, oscillate my metallic ________
+Answer: sonatas
+
+Category: Paper
+Question: What size is A-0 paper?
+Answer: one Square Meter
+
+Category: People
+Question: Who is David John Cornwell better known as?
+Answer: John Le Carré
+
+Category: Periodic Table
+Question: What is the first element in alphabetical order?
+Answer: Actinium
+
+Category: Periodic table
+Question: What is the last element in alphabetical order?
+Answer: Zirconium
+
+Category: Philisophy
+Question: In addition to writing novels, Jonathan Swift also wrote social and philosophical commentary. In one satirical piece, "A Modest Proposal," what did he suggest should be made out of the skin of children?
+Answer: gloves
+
+Category: Philosophy
+Question: -isms: The belief in God as a "divine clockmaker," originating in the age of Enlightenment.
+Answer: Deism
+
+Category: Philosophy
+Question: -isms: This branch of philosophy, characterised by the idea: "The greatest pleasure and happiness for the greatest number," was founded by Jeremy Bentham and James Mill.
+Answer: Utilitarianism
+
+Category: Philosophy
+Question: After contracting this disease, Friedrich Nietzsche went crazy and eventually died.
+Answer: syphilis
+
+Category: Philosophy
+Question: As opposed to Plato, this Greek philosopher believed knowledge was a process of observation and classication.
+Answer: Aristotle
+
+Category: Philosophy
+Question: Author of "The World as Will" and "Representation", pessimistic forbearer of Nietzsche?
+Answer: Arthur Schopenhauer
+Regexp: (Arthur )?Schopenhauer
+
+Category: Philosophy
+Question: Book: Thus Spoke _______ (Friedrich Nietzsche)
+Answer: Zarathustra
+
+Category: Philosophy
+Question: Early deconstructionist, Jacques _____
+Answer: Derrida
+
+Category: Philosophy
+Question: Epicurus, who believed that pleasure is the highest good, gave us which term synonymous with hedonistic?
+Answer: epicurean
+
+Category: Philosophy
+Question: In linguistics, this frenchman presented the concept of the signifier and the signified (surname only)?
+Answer: Saussare
+
+Category: Philosophy
+Question: In what he called his "Copernican Revolution" this German philosopher proposed that the mind imposes space time, and causality on nature. He is Immanuel ---- ?
+Answer: Immanuel #Kant#
+
+Category: Philosophy
+Question: Pessimistic author of The World as Will and Representation. Major influence on Nietzsche.
+Answer: Arthur #Schopenhauer#
+
+Category: Philosophy
+Question: Sartre, Camus and de Beauvoir all belonged to a movement known as ----
+Answer: Existentialism
+
+Category: Philosophy
+Question: This Greek philosopher believed man is born with all knowledge and life and education are processes of remembering what is forgotten at birth.
+Answer: Plato
+
+Category: Philosophy
+Question: What is the working class called in marxist terminology?
+Answer: proletariat
+
+Category: Philosophy
+Que
+Answer: Zeeman effect
+
+Category: Physics
+Question: Light rays consist of small packets of energy called .....
+Answer: photons
+
+Category: Physics
+Question: The force perpendicular to the surface of an object which counters the gravitational force?
+Answer: Normal Force
+
+Category: Physics
+Question: The unit of electrical resistance is the .....
+Answer: ohm
+
+Category: Physics
+Question: Units of frequency?
+Answer: Hertz
+
+Category: Physics
+Question: Units of frequency?
+Answer: Hertz
+
+Category: Physics
+Question: What is the clear homogeneous liquid portion of a nuclear protoplasm?
+Answer: karyolymph
+
+Category: Physics
+Question: Which colour has highest wavelength in the visible spectrum?
+Answer: red
+
+Category: Physics
+Question: Which particles are emitted by cathode ray tubes?
+Answer: electrons
+
+Category: Places
+Question: Where is the biggest mosque in the world?
+Answer: Madina, Saudi Arabia
+
+Category: Places
+Question: Which establishments don't have windows or watches?
+Answer: casino's
+Regexp: casino'?s
+
+Category: Plants
+Question: "Scotch pine", "Douglas fir", "Noble fir", "Fraser fir" are all commonly used as what?
+Answer: christmas trees
+Regexp: christmas
+
+Category: Politics
+Question: Margaret Thatcher was what?
+Answer: First Woman Prime Minister
+
+Category: Politics
+Question: What title to the Ambassadors of Britian Get given?
+Answer: Ambassador to the Court of Saint James
+Level: hard
+
+Category: Population
+Question: What is the current world population, to the nearest billion?
+Answer: six
+Regexp: (six|6)
+
+Category: Psychology
+Question: A psychological disorder in which the patient refuses to eat.
+Answer: #anorexia# nervosa
+
+Category: Psychology
+Question: He developed the theory of the 'collective unconscious' and was also interested in dream interpretation.
+Answer: Carl Gustav #Jung#
+
+Category: Psychology
+Question: Which behaviorist conducted the "Little Albert" experiment?
+Answer: John #Watson#
+
+Category: Quick! Quick!
+Question: How many letters does abbreviation have?
+Answer: 12
+Regexp: (12|Twelve)
+
+Category: Quick! Quick!
+Question: What key is to the right of T on a keyboard?
+Answer: Y
+
+Category: Quick! Quick!
+Question: What letters are missing from here - abcdeghijlmopqrstuvwxy?
+Answer: f,k,n,z
+Regexp: f,?k,?n,?z
+
+Category: Quizzes
+Question: How many points are required to win this quiz?
+Answer: 30
+Regexp: (30|thirty)
+
+Category: Quotes
+Question: What Follows the Phrase 'Eye for Eye, Tooth for Tooth'?
+Answer: Hand for Hand, Foot for Foot
+
+Category: Quotes
+Question: Who Said "Who controls the past controls the future. Who controls the present controls the past"?
+Answer: George #Orwell#
+
+Category: Quotes
+Question: Who said  "The reports of my death are greatly exaggerated."?
+Answer: Mark #Twain#
+
+Category: Quotes
+Question: Who said "For every action there is an equal and opposite reaction"?
+Answer: Albert #Eienstein#
+
+Category: Quotes
+Question: Who said "Forgive your enemies, but never forget their names"?
+Answer: John F. Kennedy
+Regexp: (jfk|kennedy|john (f.? )?kennedy)
+
+Category: Quotes
+Question: Who said "That's one small step for man, one giant leap for mankind"?
+Answer: Neil #Armstrong#
+
+Category: Quotes
+Question: Who said "The hunger for love is much more difficult to remove than the hunger for bread."?
+Answer: Mother #Teresa#
+
+Category: Quotes
+Question: Who said 'We're not in the hamburger business, we're in showbusiness'?
+Answer: Ray #Kroc#
+
+Category: Quotes
+Question: who said  "He who opens a school door, closes a prison"?
+Answer: Victor #Hugo#
+
+Category: Quotes
+Question: who said  "Religion... is the opium of the masses"?
+Answer: Karl #Mar#x
+
+Category: Quotes
+Question: who said  "Today Europe tomorrow the world"?
+Answer: Adolf #Hitler#
+
+Category: Radio
+Question: Of what is 'FM' an abbreviation?
+Answer: frequency modulation
+
+Category: Recreational Chemistry
+Question: Which organic compound is the psychoactive ingredient in Budweiser?
+Answer: ethanol
+Regexp: (ethanol|ethyl alcohol)
+
+Category: Religion
+Question: According to the Bible, how many years did Methuselah live?
+Answer: 969
+
+Category: Religion
+Question: According to the Bible, who were the brothers of Jesus?
+Answer: James and John
+Regexp: (James( and| &|,)? John|John( and| &|,)? James)
+
+Category: Religion
+Question: In theology, the study of final things such as death, judgement and the end of the world is called:
+Answer: eschatology
+
+Category: Religion
+Question: These wounds of christ mysteriously appear on believers who sometimes weep blood as well.
+Answer: stigmata
+
+Category: Religion
+Question: This roman soldier pierced the crucified Christ on His side with his spear.
+Answer: Longinus
+
+Category: Religion
+Question: What animal's meat can a Hindu not eat?
+Answer: cow
+
+Category: Religion
+Question: What animal's meat can a Muslim not eat?
+Answer: pig
+
+Category: Religion
+Question: What is the 1st book of the Hindu scripture?
+Answer: Rig Veda
+
+Category: Religion
+Question: What is the name given to the supreme reality in Hinduism?
+Answer: Brahman
+
+Category: Religion
+Question: What is the name of the field where Christ was crucified?
+Answer: Calvary
+
+Category: Religion
+Question: What is the shortest verse in the bible? (John 11:35)
+Answer: #Jesus wept#.
+
+Category: Religion
+Question: What was the first sign shown to Moses by God according to the Bible?
+Answer: burning bush
+
+Category: Religion
+Question: Who is referred to in the New Testament as 'the disciple Jesus loved'?
+Answer: John
+
+Category: Religious Stuff
+Question: The Lord's Prayer appears in the Bible how many times (written numerically)?
+Answer: two
+Regexp: (2|two)
+
+Category: Royalty
+Question: Who is the Prince of Wales?
+Answer: Prince Charles
+
+Category: Sceince
+Question: What is Borborygmus?
+Answer: Stomach Noises
+
+Category: Science
+Question: A scientist who studies reptiles and amphibians is known as a:
+Answer: Herpetologist
+
+Category: Science
+Question: He is the Most Durable TV Astronomer
+Answer: Patrick Moore
+
+Category: Science
+Question: In the electomagnetic spectrum, what comes between X-rays and Light?
+Answer: ultraviolet light
+
+Category: Science
+Question: On the Moh Hardness scale what has a hardness of 10?
+Answer: Diamond
+
+Category: Science
+Question: Sound travels fastest through which state of matter?
+Answer: solid
+
+Category: Science
+Question: The Carloline Institute of Stockholm won the nobel prize for what?
+Answer: Physiology and Medicine
+Regexp: (physiology|medicine) (and|&) (physiology|medicine)
+
+Category: Science
+Question: The study of the size, composition and distribution of the human population.
+Answer: demography
+
+Category: Science
+Question: What 2 planets do not have moons?
+Answer: Mercury and Venus
+Regexp: (mercury|venus) (and|&) (mercury|venus)
+
+Category: Science
+Question: What did Einstein get the nobel prize for?
+Answer: The Photelectric effect
+Regexp: (The )?photelectric effect
+
+Category: Science
+Question: What does LPG stands for?
+Answer: Liquid Petroleum Gas
+
+Category: Science
+Question: What engery does an Eolic power station?
+Answer: Wind Power
+
+Category: Science
+Question: What is Cytology the study of?
+Answer: The Structure of Cells
+
+Category: Science
+Question: What is the chief constituent of air?
+Answer: Nitrogen
+
+Category: Science
+Question: What is the fourth state of matter?
+Answer: liquid crystals
+Regexp: liquid crystal'?s?
+
+Category: Science
+Question: What is the second hardest gem after diamond?
+Answer: sapphire
+
+Category: Science
+Question: What science does Professor Stephen Hawking study and teach?
+Answer: astrophysics
+
+Category: Science
+Question: What two planets dont have moons?
+Answer: Mercury and Venus
+Regexp: (Mercury(,| and| +| &) Venus|Venus(,| and| +| &) Mercury)
+
+Category: Science
+Question: What would a Conchologist be intrested in?
+Answer: shells
+
+Category: Science
+Question: Who devised the periodic table of elements?
+Answer: Mendelev
+
+Category: Science
+Question: Who discovered Vitamin C?
+Answer: Linus Pauling
+
+Category: Science
+Question: Who invented the centigrade scale?
+Answer: Anders Celsius
+
+Category: Science
+Question: Who is the only person two win two nobel prizes?
+Answer: Marie Curie
+Regexp: (Madamme )?(Marie )?Curie
+
+Category: Science
+Question: Who made the first phone call to the moon?
+Answer: Richard Nixon
+
+Category: Science
+Question: what Vitamin is Thiamine?
+Answer: Vitamin #B1#
+
+Category: Science
+Question: what period Came after the triassic?
+Answer: Jurassic
+
+Category: Shakespeare
+Question: Whose ghost appears at the dinner table in 'Macbeth'?
+Answer: Banquo's
+Regexp: Banquo'?s
+
+Category: Shapes
+Question: A "gyre" is another term for what shape?
+Answer: coil
+
+Category: Show Biz
+Question: What is Kenny G's real surname?
+Answer: Gorelick
+
+Category: Show Biz
+Question: What was Marilyn Monroe's given name at birth?
+Answer: Norma Jean Mortenson
+
+Category: Similes
+Question: As light as a .......
+Answer: feather
+
+Category: Similes
+Question: As old as the .....?
+Answer: hills
+Regexp: hill'?s
+
+Category: Similes
+Question: As old as the ...?
+Answer: hills
+
+Category: Space
+Question: How many Astronaughs crewed the Gemini series of Spacecraft?
+Answer: Two
+
+Category: Space
+Question: The Sun is how much more dense than water?
+Answer: 1.41
+
+Category: Space
+Question: What is a Blue Moon?
+Answer: 2nd full moon in 1 month
+
+Category: Space
+Question: What is the only man-made structure on earth that can been seen from space?
+Answer: Great Wall Of China
+
+Category: Space
+Question: What lies between mars and jupiter?
+Answer: the asteroid belt
+
+Category: Space Travel
+Question: Who was the first man in space?
+Answer: Yuri #Gagarin#
+
+Category: Sport
+Question: How many hurdles in a 400m hurdle race?
+Answer: 10
+
+Category: Sport
+Question: How many pockets on a standard snooker table?
+Answer: 6
+
+Category: Sport
+Question: In american football where is the Orange Bowl?
+Answer: Miami
+
+Category: Sport
+Question: In baseball, how many outs are there in an inning?
+Answer: six
+Regexp: (six|6)
+
+Category: Sport
+Question: In what sport would you find a 'Sukahara'?
+Answer: Gymnastics
+
+Category: Sport
+Question: In which country is the famous Maracana stadium?
+Answer: brazil
+
+Category: Sport
+Question: Polo consists of 8 periods called what?
+Answer: Chukkers
+
+Category: Sport
+Question: The greyhound, along with this smaller relative, is used in the sport of coursing?
+Answer: Whippet
+
+Category: Sport
+Question: The name of the only weapon in women's fencing?
+Answer: foil
+
+Category: Sport
+Question: The two tire manufacturers in F1 are Bridgestone and ........?
+Answer: Michelin
+
+Category: Sport
+Question: This football team was formerly known as the Frankford Yellow Jackets?
+Answer: Philadelphia Eagles
+
+Category: Sport
+Question: What are a cheesboard's vertical rows called?
+Answer: Files
+
+Category: Sport
+Question: What are a chessboard's horizontal rows called?
+Answer: Ranks
+
+Category: Sport
+Question: What are the only two colours a table tennis ball is allowed to be in competitions?
+Answer: White and Yellow
+Regexp: (White(,| and| +| &) Yellow|Yellow(,| and| +| &) White)
+
+Category: Sport
+Question: What football team was formerly known as the Frankford Yellow Jackets?
+Answer: Philadelphia Eagles
+
+Category: Sport
+Question: What is James Naismith best known for?
+Answer: inventing Basketball
+
+Category: Sport
+Question: What sport do neither participents or spectators know the score until the end?
+Answer: boxing
+
+Category: Sport
+Question: Whats the main feature of a speedway motorbike?
+Answer: No Brakes
+
+Category: Sport
+Question: Which European club has won the most european cups in the 90s?
+Answer: AC Milan
+
+Category: Sport
+Question: Which country was judo developed in?
+Answer: Japan
+
+Category: Sport
+Question: Which team won the UEFA cup this year?
+Answer: Liverpool
+
+Category: Sport
+Question: Which weight division in boxing lies between flyweight and featherweight?
+Answer: bantamweight
+
+Category: Sport
+Question: Which weight division in boxing lies between flyweight and featherweight?
+Answer: batamweight
+
+Category: Sport
+Question: Who fell behind Roger Maris in 1961 for the homerun record?
+Answer: Mickey Mantle
+
+Category: Sport
+Question: Who was the first american to win the Formula 1 championship?
+Answer: Phil Hill
+
+Category: Sport
+Question: Who was the first unseeded player to win Wimbeldon?
+Answer: Boris Becker
+
+Category: Sport
+Question: Who won the 2001 FA Cup?
+Answer: Liverpool
+
+Category: Sports
+Question: What is the international governing board of football (soccer)?
+Answer: FIFA
+
+Category: Sports
+Question: Which Grand Slam tennis event is played on a clay surface?
+Answer: French Open
+
+Category: Sports Anagrams
+Question: Frown, it is not well regarded.
+Answer: World Wrestling Federation
+
+Category: Stationery
+Question: How many bends in a standard paperclip?
+Answer: three
+Regexp: (three|3)
+
+Category: Stupid Americans
+Question: Every citizen of Kentucky is required by law to take a what once a year?
+Answer: bath
+
+Category: Stupid Americans
+Question: The Luxor hotel in Las Vegas has the most powerful what?
+Answer: light
+
+Category: TV
+Question: Tinky winky, Dipsy LaLa and Po are know as what?
+Answer: The #Teletubbies#
+
+Category: TV Series
+Question: Who played Charlie in Charlies Angels?
+Answer: John Forsythe
+
+Category: TV Shows
+Question: In the 70s Hit Captain Scarlet and the Mysterons what is the name of the company Scralet works for?
+Answer: Spectrum
+
+Category: TV Trivia
+Question: Josie and the ________
+Answer: Pussycats
+
+Category: TV Trivia
+Question: What was the name of the restaurant the TV series "Happy Days"?
+Answer: Arnolds
+Regexp: Arnold'?s
+
+Category: TV Trivia
+Question: Which TV horse could talk?
+Answer: Mr. Ed
+Regexp: Mr\.? Ed
+
+Category: Technology
+Question: What colour is the 'Black box' on commercial planes?
+Answer: Orange
+
+Category: Technology
+Question: What does the CAT in CAT-SCAN stand for?
+Answer: Computerised Axial Tomography
+
+Category: Technology
+Question: What was the Jaguar Car called before 1945?
+Answer: SS
+
+Category: Technology
+Question: Which Writer established the three laws of robotics?
+Answer: Isaac Asimov
+
+Category: Technology
+Question: Who was the founder of Lotus Cars Ltd.?
+Answer: Colin Chapman
+
+armed, is played by who?
+Answer: Shannon Doherty
+
+Category: Television
+Question: Where does Gonzo from the Muppet Show come from?
+Answer: outer space
+
+Category: Temperature
+Question: What is -459.7 F also know as?
+Answer: Absolute Zero
+
+Category: Textiles
+Question: This is the Southeast Asian method of dying fabric using wax to create designs.
+Answer: batik
+
+Category: That's showbiz for ya!
+Question: Michael Jackson caught fire while filming a commercial for which carbonated beverage?
+Answer: Pepsi
+
+Category: The Bible
+Question: What is the last word in the New Testament?
+Answer: Amen
+
+Category: The Body
+Question: Whats the largest organ in the human body?
+Answer: Skin
+
+Category: The Metric System
+Question: To the nearest 0.1 km, how many kilometers in a mile?
+Answer: 1.6
+
+Category: Theatre
+Question: What Gilbert and Sullivan work tells the story of a Japanese emperor who bans flirting?
+Answer: The #Mikado#
+
+Category: Theology
+Question: Where do the souls of unbaptised babies go after death, according to Catholocism?
+Answer: Limbo
+
+Category: Theology
+Question: Where do the souls of unbaptised babies go after death, according to Catholocism?
+Answer: limbo
+
+Category: Time
+Question: What is 'Zulu' time?
+Answer: Greenwich Mean Time
+
+Category: US Presidents
+Question: Who was the youngest American President
+Answer: Theodore Roosevelt
+
+Category: Very silly countries
+Question: The Presidential highway links the towns of Gore and Clinton in which country?
+Answer: New Zealand
+
+Category: Vocabulary
+Question: An adjective meaning 'pertaining to the sun.'
+Answer: solar
+
+Category: Weight
+Question: How much does a cubic meter of water weigh?
+Answer: One Ton
+
+Category: Yanks
+Question: What house was the biggest in america until the Cival war?
+Answer: The White House
+Regexp: white
+
+Category: Yum
+Question: What is the full name of the flavour enhancer MSG?
+Answer: Monosodium glutamate
+
+Category: americans again, Duh
+Question: In what city in Georgia is it illegal to tie a giraffe to a telephone pole or street lamp?
+Answer: Atlanta
+
+Category: ancient Stuff
+Question: Roman statues were made with detachable whats, so that one what could be removed and replaced by another?
+Answer: heads
+
+Category: dont say it
+Question: At funerals in ancient China, when the lid of the coffin was closed, mourners took a few steps backward incase their WHAT got caught in the box?
+Answer: shadow
+
+Category: english
+Question: The longest one-syllable word in the English language is?
+Answer: screeched
+
+Category: low Countries
+Question: The lowest country in the world is?
+Answer: The Netherlands
+Regexp: (The Netherlands|Holland)
+
+Category: measurments
+Question: Pony, Shot and Jigger are all units to measure what?
+Answer: Spirits
+
+Category: quote
+Question: Who said "The great masses of the people will more easily fall victims to a big lie than to a small one."?
+Answer: Adolf Hitler
+Regexp: Hitler
+
+Category: quote
+Question: Who said "The great masses of the people will more easily fall victims to a big lie than to a small one."?
+Answer: Adolf Hitler
+
+Category: silly Americans
+Question: Teddy Roosevelt banned the a what from the White House for environmental reasons?
+Answer: Christmas Tree
+
+Category: silly flags
+Question: Which nation has an AK-47 assault rifle on its flag?
+Answer: Mozambique
+
+Category: stupid Fish
+Question: A goldfish has a memory of how many seconds?
+Answer: three
+Regexp: (3|one)
+
+Category: stupid Rivers
+Question: The only river that flows both north and south of the equator is the?
+Answer: congo
+
+Category: useless Stuff
+Question: The only place in the world where one can see the sun rise on the Pacific Ocean and set on the Atlantic is in which country?
+Answer: Panama
+
+Category: Abbreviations
+Question: What do the initials 'VCP' stand for?
+Answer: Video Cassette Player
+
+Category: Abbreviations
+Question: What do the initials 'VCR' stand for?
+Answer: Video Cassette Recorder
+
+Category: Abbreviations
+Question: What does 'A&W' (of root beer fame) stand for ?
+Answer: Allen & Wright
+Regexp: Allen ?(and|&) ?Wright
+
+Category: Abbreviations
+Question: What does 'AOL' stand for?
+Answer: America Online
+
+Category: Abbreviations
+Question: What does S.O.S. stand for?
+Answer: Save Our Souls
+
+Category: Acronyms
+Question: What does N.A.S.A stand for?
+Answer: National Aeronautics and Space Administration
+
+Category: Acronyms
+Question: What does the acronym 'scuba' mean?
+Answer: Self Contained Underwater Breathing Apparatus
+Regexp: Self[- ]Contained Underwater Breathing Apparatus
+
+Category: Advertising
+Question: Who is the dog on the crackerjack box?
+Answer: Bingo
+
+Category: Agriculture
+Question: What is ground being 'rested' for a season called?
+Answer: fallow
+
+Category: Aircraft
+Question: After what were the B52 bombers named?
+Answer: a fifties #hairdo#
+Regexp: (hair ?style|hair ?do)
+
+Category: Aircraft
+Question: How many engines are on a B52 bomber?
+Answer: eight
+Regexp: (eight|8)
+
+Category: Aircraft
+Question: How many gallons of fuel does a jumbo jet use during take off?
+Answer: four thousand
+Regexp: (Four thousand|4[, ]?000)
+
+Category: Aircraft
+Question: What does a pilot drop to slow an airplane?
+Answer: flaps
+
+Category: Aircraft
+Question: What is the world's fastest passenger aircraft?
+Answer: Concorde
+
+Category: Aircraft
+Question: What type of craft is the US's Airforce One?
+Answer: Boeing #747#
+
+Category: Aircraft
+Question: Whic country developed the first jet fighter?
+Answer: Germany
+
+Category: Aircraft
+Question: Which two nations built the concorde?
+Answer: Britain and France
+Regexp: (Britain|France) (and|&) (Britain|France)
+
+Category: Aircraft
+Question: Who built the 'Cherokee' and 'Comanche' aircraft?
+Answer: Piper
+
+Category: Aircraft
+Question: Who built the hurricane aircraft?
+Answer: Hawker
+
+Category: Alcohol
+Question: From what is the liqueur kirsch made?
+Answer: cherries
+Regexp: cherr(y|ies)
+
+Category: Alcohol
+Question: From which plant is tequila derived?
+Answer: cactus
+
+Category: America
+Question: As what is California also known?
+Answer: Golden State
+
+Category: America
+Question: As what is Minnesota also known?
+Answer: Gopher State
+
+Category: America
+Question: What city is also known as Beantown?
+Answer: Boston
+
+Category: America
+Question: What state is 'The Golden State'?
+Answer: California
+
+Category: America
+Question: What state is also called the 'Garden State'?
+Answer: New Jersey
+
+Category: America
+Question: What state is the 'Hoosier State'?
+Answer: Indiana
+
+Category: America
+Question: Where are the headquarters of the CIA?
+Answer: #Langley#, Virginia
+
+Category: America
+Question: Which date is inscribed on the book held by the Statue Of Liberty?
+Answer: July 4 1776
+
+Category: American Cities
+Question: What is the most air polluted city in the United States?
+Answer: Los Angeles
+Regexp: (Los Angeles|LA)
+
+Category: American General Knowledge
+Question: Where is the Kitty Hawk?
+Answer: The #Smithsonian# Institute
+
+Category: American History
+Question: What mountain has the figures of three mounted confederate heroes of the Civil War?
+Answer: #Stone# Mountain
+
+Category: American History
+Question: What state is only part of the United States by treaty?
+Answer: Texas
+
+Category: Anagrams
+Question: Which two fruits are an anagram of each other?
+Answer: lemon and melon
+Regexp: [ml]e[ml]on (and|&) [ml]e[ml]on
+
+Category: Anatomy
+Question: How many litres of air is in an adult lung?
+Answer: five
+Regexp: (five|5)
+
+Category: Anatomy
+Question: How many times do your ribs move every year during breathing?
+Answer: five million
+Regexp: ((Five|5) million|5[ ,]?000[ ,]?000)
+
+Category: Anatomy
+Question: Like fingerprints, what other print is individual?
+Answer: #tongue#prints
+
+Category: Anatomy
+Question: Of what does the typical man have 13,000?
+Answer: whiskers
+
+Category: Anatomy
+Question: What do the auricularis muscles move?
+Answer: #ear#s
+
+Category: Anatomy
+Question: What is the Scientific name for the eardrum?
+Answer: tympanic membrane
+
+Category: Anatomy
+Question: What is the common name for the scapula?
+Answer: shoulder blade
+
+Category: Anatomy
+Question: What is the common name for the sternum?
+Answer: breastbone
+
+Category: Anatomy
+Question: What is the common name for the tympanic membrane?
+Answer: eardrum
+Regexp: ear ?drum
+
+Category: Anatomy
+Question: What is the second largest bone in the foot?
+Answer: talus
+
+Category: Anatomy
+Question: What is the smallest bone in the human body?
+Answer: #stirrup# bone
+
+Category: Anatomy
+Question: Where are one quarter of the bones in the human body?
+Answer: feet
+
+Category: Anatomy
+Question: Which is the most sensitive finger?
+Answer: forefinger
+Regexp: (fore|index)
+
+Category: Animal Kingdom
+Question: As what is a camelopard also known?
+Answer: giraffe
+
+Category: Animal Kingdom
+Question: As what is a giraffe also known?
+Answer: camelopard
+
+Category: Animal Kingdom
+Question: As what is a moose also known?
+Answer: algonquin
+
+Category: Animal Kingdom
+Question: As what is an algonquin more commonaly known?
+Answer: moose
+
+Category: Animal Kingdom
+Question: At what age does a filly become a mare?
+Answer: five
+Regexp: (five|5)
+
+Category: Animal Kingdom
+Question: Does a wild rabbit live 10, 15 or 20 years?
+Answer: 10
+Regexp: (ten|10)
+
+Category: Animal Kingdom
+Question: How fast (mph) can a kangaroo hop?
+Answer: forty
+Regexp: (forty|40)
+
+Category: Animal Kingdom
+Question: How many hours a day does a ferret sleep?
+Answer: twenty
+Regexp: (twenty|20)
+
+Category: Animal Kingdom
+Question: How many hours does an antelope sleep at night?
+Answer: one
+Regexp: (one|1)
+
+Category: Animal Kingdom
+Question: How many teeth does a walrus have?
+Answer: eighteen
+Regexp: (eighteen|18)
+
+Category: Animal Kingdom
+Question: If a robin's egg is put in vinegar for thirty days, what colour does it become?
+Answer: yellow
+
+Category: Animal Kingdom
+Question: Name one male fish that gives birth?
+Answer: sea horse or pipe fish
+Regexp: (sea ?horse|pipe ?fish)
+Tip: s.. h.... or p... f...
+Tip: .e. .o... or .i.. .i..
+Tip: ..a ..r.. or ..p. ..s.
+Tip: ... ...s. or ...e ...h
+Tip: ... ....e or .... ....
+
+Category: Animal Kingdom
+Question: Of what are walrus tusks made?
+Answer: ivory
+
+Question: If body temperature was 86 degrees, how many years would a man man live?
+Answer: two hundred
+Regexp: (two hundred|200)
+
+Question: In 1986, what was the maximum fuel capacity (in litres) imposed in Formula 1 racing?
+Answer: 195
+Regexp: (one hundred (and )?ninety five|195)
+
+Category: Animal Kingdom
+Question: On what do honeybees have a type of hair?
+Answer: eyes
+
+Category: Animal Kingdom
+Question: Some animals always grow new teeth to replace the old. Name one of them!
+Answer: crocodile
+
+Category: Animal Kingdom
+Question: Some animals always grow new teeth to replace the old. Name one of them!
+Answer: shark
+
+Category: Animal Kingdom
+Question: What animal can get the disease 'heaves'?
+Answer: horse
+
+Category: Animal Kingdom
+Question: What animal can hop as fast as 40 mph?
+Answer: kangaroo
+
+Category: Animal Kingdom
+Question: What animal has red patches on its rear?
+Answer: mandrill
+
+Category: Animal Kingdom
+Question: What animal lives in a form?
+Answer: hare
+
+Category: Animal Kingdom
+Question: What animal lives in a warren?
+Answer: rabbit
+
+Category: Animal Kingdom
+Question: What animal's milk is more than 54% fat?
+Answer: humpback #whale#
+
+Category: Animal Kingdom
+Question: What are the only other animals on which the pill works?
+Answer: #gorilla#s
+
+Category: Animal Kingdom
+Question: What bird is associated with Lundy Island?
+Answer: puffin
+
+Category: Animal Kingdom
+Question: What colour is a robin's egg?
+Answer: blue
+
+Category: Animal Kingdom
+Question: What comprises than 54% of humpback whale's milk?
+Answer: fat
+
+Category: Animal Kingdom
+Question: What dog is named after a Mexican state?
+Answer: chihuahua
+
+Category: Animal Kingdom
+Question: What herbivore sleeps one hour a night?
+Answer: antelope
+
+Category: Animal Kingdom
+Question: What insect has a type of hair on it's eyes?
+Answer: honey#bees#
+
+Category: Animal Kingdom
+Question: What is a female deer called?
+Answer: doe
+
+Category: Animal Kingdom
+Question: What is a male deer called?
+Answer: buck
+
+Category: Animal Kingdom
+Question: What is a marsupium?
+Answer: pouch
+
+Category: Animal Kingdom
+Question: What is a word for a castrated ram?
+Answer: wether
+
+Category: Animal Kingdom
+Question: What is a young whale called?
+Answer: calf
+
+Category: Animal Kingdom
+Question: What is another name for the coyote?
+Answer: prairie wolf
+
+Category: Animal Kingdom
+Question: What is another name for the prairie wolf?
+Answer: coyote
+
+Category: Animal Kingdom
+Question: What is the chihuahua named after?
+Answer: A #Mexican state#
+Regexp: (Mexican state|state in Mexico)
+
+Category: Animal Kingdom
+Question: What is the heaviest snake?
+Answer: anaconda
+
+Category: Animal Kingdom
+Question: What is the largest lizard?
+Answer: Komodo Dragon
+
+Category: Animal Kingdom
+Question: What is the longest venomous snake?
+Answer: king cobra
+
+Category: Animal Kingdom
+Question: What is the scientific name for a turkey's wishbone?
+Answer: furcula
+
+Category: Animal Kingdom
+Question: What is the technical name for an animal's pouch?
+Answer: marsupium
+
+Category: Animal Kingdom
+Question: What lives in a formicary?
+Answer: #ant#s
+
+Category: Animal Kingdom
+Question: What type of frog is the smallest frog?
+Answer: gold frog
+
+Category: Animal Kingdom
+Question: What was the first animal on the endangered species list?
+Answer: peregrine falcon
+
+Category: Animal Kingdom
+Question: What well known marsupial is the wallaby related to?
+Answer: kangaroo
+
+Category: Animal Kingdom
+Question: Where do ants live?
+Answer: formicary
+Regexp: for[mn]icary
+
+Category: Animal Kingdom
+Question: Which is the largest African bird of prey?
+Answer: lammergeyer
+
+Category: Animal Kingdom
+Question: Which is the largest aquatic bird?
+Answer: albatross
+
+Category: Animal Kingdom
+Question: Which is the largest known butterfly?
+Answer: Queen Alexandra's Birdwing
+Regexp: Queen Alexandra('s)? Bird ?wing
+
+Category: Animal Kingdom
+Question: Which is the only animal other than humans that can get leprosy?
+Answer: armadillos
+
+Category: Animal Kingdom
+Question: Which mammals fly?
+Answer: bats
+
+Category: Animal Kingdom
+Question: Which snake kills the most humans?
+Answer: king cobra
+
+Category: Animal Kingdom
+Question: With which island is the puffin associated?
+Answer: #Lundy# Island
+
+Category: Animal kingdom
+Question: Where are there over 58 million dogs?
+Answer: USA
+Regexp: (U.?S.?A?.?|(United )?(States )?(of )?America)
+
+Category: Animals
+Question: What is the most venomous snake (no, it's not the king cobra!)?
+Answer: Inland #Taipan#
+
+Category: Archaeology
+Question: Approximately how many years old is the first known written advertisement?
+Answer: three thousand
+Regexp: (three thousand|3[, ]?000)
+
+Category: Archaeology
+Question: In which ruins was the first known written advertisement found?
+Answer: Thebes
+
+Category: Archaic Terms
+Question: What date is the 'Ides' of March?
+Answer: Fifteenth
+Regexp: (Fifteen|15)
+
+Category: Architecture
+Question: Which famous million dollar building cost more than a million dollars?
+Answer: Sydney #Opera House#
+
+Category: Art
+Question: Who painted 'Irises'?
+Answer: Vincent #Van Gogh#
+
+Category: Arts
+Question: What is the art of tracing designs and making impressions of them called?
+Answer: lithography
+
+Category: Arts
+Question: Which is the largest museum in the world?
+Answer: Louvre
+
+Category: Arts
+Question: Who is a successful recording artist, talented landscape artist, and author of children's books?
+Answer: Ricky Van Shelton
+
+Category: Astology
+Question: Who was born when Pluto, the astrological sign for death, was directly above Dallas, Texas?
+Answer: John F. #Kennedy#
+
+Category: Astrology
+Question: What is the astrological sign for death?
+Answer: Pluto
+
+Category: Astrology
+Question: What is the zodiacal symbol for Capricorn?
+Answer: goat
+
+Category: Astrology
+Question: Which constellation is represented by a goat?
+Answer: Capricorn
+
+Category: Astronomy
+Question: As what is Polaris also known?
+Answer: North Star
+
+Category: Astronomy
+Question: As what is the North Star also known?
+Answer: Polaris
+
+Category: Astronomy
+Question: Saturday is named after which planet?
+Answer: Saturn
+
+Category: Astronomy
+Question: What constellation is represented by scales?
+Answer: Libra
+
+Category: Astronomy
+Question: What is the most essential tool in astronomy?
+Answer: telescope
+
+Category: Astronomy
+Question: What is the name given to a group of stars?
+Answer: constellation
+
+Category: Astronomy
+Question: What is the name of brightest asteroid visible from earth?
+Answer: Vesta
+
+Category: Astronomy
+Question: What is the only day named after a planet?
+Answer: Saturday
+
+Category: Astronomy
+Question: What is the small irregular white cloud that zips around Neptune approximately every 16 hours called?
+Answer: Scooter
+
+Category: Astronomy
+Question: What is the technical name for 'falling stars'?
+Answer: meteors
+
+Category: Astronomy
+Question: What planet is nearest the sun?
+Answer: Mercury
+
+Category: Astronomy
+Question: When does a full moon rise?
+Answer: sunset
+
+Category: Astronomy
+Question: Which is the only planet that rotates clockwise?
+Answer: Venus
+
+Category: Astronomy
+Question: Who coined the theory that the earth revolves around the sun?
+Answer: Nicolaus #Copernicus#
+
+Category: Astronomy
+Question: Who discovered the four largest moons of Jupiter?
+Answer: Galileo
+
+Category: Astronomy
+Question: Who invented the telescope?
+Answer: #Galileo# Galilei
+
+Category: Atmosphere
+Question: What is the stratosphere immediately above?
+Answer: troposphere
+
+Category: Atmosphere
+Question: What is the troposphere immediately lower than?
+Answer: stratosphere
+
+Category: Aviation
+Question: How many 'Air Force One'(s) are there?
+Answer: two
+Regexp: (two|2)
+
+Category: Baseball
+Question: Who wore a cabbage leaf under his cap?
+Answer: Babe Ruth
+
+Category: Beverages
+Question: What drink is named after the queen of England who was famous for her 'sanguinary' persecution of the protestants?
+Answer: Bloody Mary
+
+Category: Beverages
+Question: What is made of fermented grape juice?
+Answer: wine
+
+Category: Big Peepers
+Question: Which animal has the largest eyes?
+Answer: giant squid
+
+Category: Biology
+Question: As what is haemophilia also known?
+Answer: royal disease
+
+Category: Biology
+Question: Of what is keratitis an inflammation?
+Answer: cornea
+
+Category: Biology
+Question: On what side should you sleep to improve digestion?
+Answer: right
+
+Category: Biology
+Question: To what disability can keratitis lead?
+Answer: blindness
+
+Category: Biology
+Question: What appears when the sun activates melanocytes?
+Answer: freckles
+
+Category: Biology
+Question: What body function is improved if you sleep on your right side?
+Answer: digestion
+
+Category: Biology
+Question: What carries sensations from the tongue to the brain?
+Answer: lingual nerve
+
+Category: Biology
+Question: What does the body release that dilates small blood vessels and so causes a person to blush?
+Answer: peptides
+
+Category: Biology
+Question: What does the lack of iodine in the diet cause?
+Answer: goitre
+Regexp: (goiter|goitre)
+
+Category: Biology
+Question: What does the pancreas produce?
+Answer: insulin
+
+Category: Biology
+Question: What element is lacking in a diet when goitre occurs?
+Answer: iodine
+
+Category: Biology
+Question: What falls out with phalacrosis?
+Answer: hair
+
+Category: Biology
+Question: What falls out with phalacrosis?
+Answer: hair
+
+Category: Biology
+Question: What fleshy muscular organ is joined to the hyoid bone?
+Answer: tongue
+
+Category: Biology
+Question: What gland secretes fluid that washes the eyes?
+Answer: #tear# gland
+
+Category: Biology
+Question: What is activated for freckles to appear?
+Answer: melanocytes
+
+Category: Biology
+Question: What is the biological name for the shin bone?
+Answer: tibia
+
+Category: Biology
+Question: What is the biological term for the voice box?
+Answer: larynx
+
+Category: Biology
+Question: What is the common name for the larynx?
+Answer: voice box
+
+Category: Biology
+Question: What is the hardest bone in the human body?
+Answer: jawbone
+
+Category: Biology
+Question: What is the latin name for the top set of vertebrae?
+Answer: cervical
+
+Category: Biology
+Question: What is the royal disease?
+Answer: haemophilia
+Regexp: ha?emophilia
+
+Category: Biology
+Question: What is the tibia more commonly known as?
+Answer: shin bone
+
+Category: Biology
+Question: What muscle is joined by the lingual nerve to the brain?
+Answer: tongue
+
+Category: Biology
+Question: What muscles move the ears?
+Answer: auricularis
+
+Category: Biology
+Question: What protein makes blood red?
+Answer: Haemoglobin
+Regexp: Ha?emolglobin
+
+Category: Biology
+Question: What small region at end of medulla oblongata serves as 'bridge' to brain?
+Answer: pons
+
+Category: Biology
+Question: When a tumour is cancerous, what is it said to be?
+Answer: malignant
+
+Category: Biology
+Question: With age, what organ shrinks faster in males than in females?
+Answer: brain
+
+Category: Birthstones
+Question: What is the birthstone for May?
+Answer: emerald
+
+Category: Birthstones
+Question: What is the birthstone for September?
+Answer: sapphire
+
+Category: Botany
+Question: Approximately how many years old are oak trees before they produce acorns?
+Answer: fifty
+Regexp: (fifty|50)
+
+Category: Botany
+Question: One ragweed plant can release approximately how many grains of pollen?
+Answer: one billion
+Regexp: (one|1) billion
+
+Category: Botany
+Question: To which family does the coffee plant belong?
+Answer: madder
+
+Category: Botany
+Question: Which tree only produces acorns after it is fifty years old?
+Answer: oak
+
+Category: Britain
+Question: How many inches tall are the bearskins worn by the guards at Buckingham Palace?
+Answer: twenty
+Regexp: (twenty|20)
+
+Category: Britain
+Question: In the House of Lords, where does the Lord Chancellor sit?
+Answer: wool#sack#
+
+Category: Britain
+Question: In which park are Queen Mary's gardens?
+Answer: #Regents# Park
+
+Category: Britain
+Question: What are the only two london boroughs that start with the letter 'e'?
+Answer: Ealing and Enfield
+Regexp: (Ealing (and |& )?Enfield|Enfield (and |& )?Ealing)
+
+Category: Britain
+Question: What does 'The Monument' in London commemorate?
+Answer: #Great Fire# of London
+
+Category: Britain
+Question: What was the second bridge built across the Thames?
+Answer: #Westminster# Bridge
+
+Category: Britain
+Question: Where is Selfridges?
+Answer: Oxford Street, London
+Regexp: Oxfions
+Question: What is a word for a sorcerer who deals in black magic?
+Answer: necromancer
+
+Category: Definitions
+Question: What is another name for a sleepwalker?
+Answer: somnambulist
+
+Category: Definitions
+Question: What is ornamental work in silver or gold thread called?
+Answer: filigree
+
+Category: Definitions
+Question: What is the name given to a pregnant goldfish?
+Answer: twit
+
+Category: Definitions
+Question: What word means 'to chew the cud'?
+Answer: ruminate
+Regexp: ruminan?t
+
+Category: Dimples
+Question: What has 336 dimples?
+Answer: a #golf ball#
+Regexp: Golf ?ball
+
+Category: Disease
+Question: Sleeping sickness is carried by which insect?
+Answer: tsetse fly
+
+Category: Disease
+Question: What disease is carried by the tsetse fly?
+Answer: sleeping sickness
+
+Category: Distress Signals
+Question: What is the international cry for help?
+Answer: mayday
+
+Category: Education
+Question: What degree do the intials 'DDS' stand for?
+Answer: Doctor of Dental Surgery
+
+Category: Egypt
+Question: What egyptian object is also known as 'the key to the Nile'?
+Answer: Ankh
+
+Category: Electronics
+Question: As what was Sony's video recorder known?
+Answer: betamax
+
+Category: Electronics
+Question: Circuits can be wired in parallel or ······?
+Answer: series
+
+Category: Entomology
+Question: What is the only insect that can turn its head?
+Answer: praying mantis
+
+Category: Environmentalism
+Question: Recycling one glass jar saves enough energy to watch TV for how many hours?
+Answer: three
+Regexp: (three|3)
+
+Category: Famous Dead Bodies
+Question: Where is Sir Herbert Baker buried?
+Answer: Westminster Abbey
+
+Category: Famous Genitals
+Question: For how much did an American urologist buy Napoleon's penis? (US Dollars)
+Answer: $#3800#
+
+Category: Famous Initials
+Question: For what are Allen and Wright most famous?
+Answer: root beer
+
+Category: Famous Places
+Question: What Surrey town is famed for its salts?
+Answer: Epsom
+
+Category: Farming
+Question: What is the most rural state in the USA?
+Answer: North Dakota
+
+Category: Fear
+Question: If hell is a lake of fire, what would the temperature be? (in degrees Fahrenheit)
+Answer: 833
+
+Category: Film and Television
+Question: Who is the main character in 'Touched By An Angel'?
+Answer: Monica
+
+Category: Flags
+Question: How many stars are there on the New Zealand flag?
+Answer: four
+Regexp: (four|4)
+
+Category: Flags
+Question: What colours are on the Belgian flag?
+Answer: yellow, black and red
+Regexp: (yellow|black|red),? ?(yellow|black|red),? ?(and )?(yellow|black|red)
+
+Category: Flags
+Question: Which country has a plain green flag?
+Answer: Libya
+
+Category: Flags
+Question: Whose flag has the national arms on one side and the treasury seal on the other?
+Answer: Paraguay
+
+Category: Flea Abilities
+Question: How many times its own length can the average flea jump?
+Answer: 150
+Regexp: (One hundred (and |& )?fifty|150)
+
+Category: Folklore
+Question: Who was the tallest of Robin Hood's men?
+Answer: Little John
+
+Category: Food
+Question: How many herbs and spices are used in Kentucky Fried Chicken?
+Answer: eleven
+Regexp: (eleven|11)
+
+Category: Food
+Question: How many pieces of bun are in a Mcdonald's Big Mac?
+Answer: three
+Regexp: (three|3)
+
+Category: Food
+Question: In which country did edam cheese originate?
+Answer: Holland
+
+Category: Food
+Question: In which country did the word 'biscuit' originate?
+Answer: France
+
+Category: Food
+Question: What breakfast cereal was invented at Battle Creek Sanitarium?
+Answer: Cornflakes
+
+Category: Food
+Question: What did Charles Jung invent?
+Answer: fortune cookies
+
+Category: Food
+Question: What is another name for the carambula?
+Answer: star fruit
+Regexp: star ?fruit
+
+Category: Food
+Question: What is the most widely used seasoning?
+Answer: salt
+
+Category: Food
+Question: What is the oldest known vegetable?
+Answer: pea
+
+Category: Food
+Question: Where were Cornflakes invented?
+Answer: Battle Creek Sanitarium
+
+Category: Food
+Question: Where were fortune cookies invented?
+Answer: United States
+
+Category: Food
+Question: Who invented fortune cookies?
+Answer: Charles Jung
+
+Category: Food
+Question: Who invented the Egg Mcmuffin?
+Answer: Ed Peterson
+
+Category: Food and Drink
+Question: What berries give gin its flavour?
+Answer: #juniper# berries
+
+Category: Fruit
+Question: A tayberry is a cross between which two fruits?
+Answer: blackberry and raspberry
+Regexp: (rasp|black)berry (and|&) (rasp|black)berry
+
+Category: Fruit
+Question: Unlike other oranges, what does a navel orange not have?
+Answer: seeds
+
+Category: Fruit
+Question: What fruits are usually served 'belle helene'?
+Answer: pears
+
+Category: Fruit
+Question: What is a cross between a blackberry and a raspberry?
+Answer: tayberry
+
+Category: Fruit
+Question: What is another name for the star fruit?
+Answer: carambula
+
+Category: Fruit
+Question: Where is most of the vitamin C in fruits?
+Answer: skin
+
+Category: Fun Runs
+Question: What is San Francisco's equivalent to Sydney's 'City To Surf' race?
+Answer: #Bay to Breakers# footrace
+
+Category: Furniture
+Question: What is the metal part of a lamp surrounding the bulb and supporting the shade called?
+Answer: harp
+
+Category: Furniture
+Question: Where did venetian blinds originate?
+Answer: Japan
+
+Category: Games
+Question: How many dots are on a twister mat?
+Answer: thirty
+Regexp: (thirty|30)
+
+Category: Games
+Question: How many folds does a Monopoly board have?
+Answer: one
+Regexp: (one|1)
+
+Category: Games
+Question: How many numbers are on the spinner in the game of 'Life'?
+Answer: ten
+Regexp: (ten|10)
+
+Category: Games
+Question: How much does Park Place cost in Monopoly (in US Dollars)?
+Answer: 450
+
+Category: Games
+Question: In a game of horseshoes, how many feet apart must the stakes be?
+Answer: forty
+Regexp: (forty|40)
+
+Category: Games
+Question: In roulette, what number is green?
+Answer: zero
+Regexp: (zero|0)
+
+Category: Games
+Question: Moving anti-clockwise on a dartboard, what is the number next to '4'?
+Answer: eighteen
+Regexp: (eighteen|18)
+
+Category: Games
+Question: To what do opposite faces of a dice always add up?
+Answer: seven
+Regexp: (seven|7)
+
+Category: Games
+Question: What is another name for the card game 'Blackjack'?
+Answer: Twenty-one
+Regexp: (twenty[- ]one|21)
+
+Category: Games
+Question: What is another name for the card game 'Twenty-one'?
+Answer: Blackjack
+
+Category: Games
+Question: What is the best possible score in blackjack?
+Answer: twenty one
+Regexp: (twenty one|21)
+
+Category: Games
+Question: What is the most popular sport in england?
+Answer: darts
+
+Category: Games
+Question: What is the tallest piece on a chessboard?
+Answer: king
+
+Category: Games
+Question: What number is at 12 o'clock on a dartboard?
+Answer: 20
+Regexp: (twenty|20)
+
+Category: Games
+Question: What sport/game is Bobby Fischer associated with?
+Answer: chess
+
+Category: Games
+Question: Where did the card game 'bridge' originate?
+Answer: Turkey
+
+Category: Games
+Question: Where does the annual Poker World Series take place?
+Answer: Las Vegas
+
+Category: Gastronomy
+Question: Approximately how many pounds of cereal will the average american/canadian eat every year?
+Answer: twelve
+Regexp: (twelve|12)
+
+Category: Gems
+Question: Peridot is the birthstone for ······?
+Answer: August
+
+Category: Gems
+Question: What is the birthstone for August?
+Answer: peridot
+
+Category: General Knowledge
+Question: During which month is the longest day in the Northern hemisphere?
+Answer: June
+
+Category: General Knowledge
+Question: During which month is the longest day in the Southern hemisphere?
+Answer: December
+
+Category: General Knowledge
+Question: During which month is the shortest day in the Northern hemisphere?
+Answer: December
+
+Category: General Knowledge
+Question: During which month is the shortest day in the Southern hemisphere?
+Answer: June
+
+Category: General Knowledge
+Question: What does a month beginning with a Sunday always have?
+Answer: Friday the 13th
+Regexp: Friday (the )?(13th|thirteenth)
+
+Category: General Knowledge
+Question: What game usually starts with 'is it animal, vegetable or mineral'?
+Answer: twenty questions
+Regexp: (twenty|20) questions
+
+Category: General Knowledge
+Question: What is the name of the office used by the president in the Whitehouse?
+Answer: Oval office
+
+Category: General Knowledge
+Question: What is viewed during a a pyrotechnic display?
+Answer: fireworks
+
+Category: General Knowledge
+Question: What system do the blind use for reading?
+Answer: braille
+
+Category: General Knowledge
+Question: Where will children as young as 15 be jailed for cheating on their finals?
+Answer: Bangladesh
+
+Category: General Knowledge
+Question: With what day does a month start if it has a Friday the 13th?
+Answer: Sunday
+
+Category: Genetics
+Question: How many chromosomes do each body cell contain?
+Answer: forty six
+Regexp: (forty[- ]six|46)
+
+Category: Geograhy
+Question: What is the capital of Democratic Republic of the Congo?
+Answer: Kinshasa
+
+Category: Geography
+Question: Abuja is the capital of ······?
+Answer: Nigeria
+
+Category: Geography
+Question: Accra is the capital of ······?
+Answer: Ghana
+
+Category: Geography
+Question: Albany is the capital of ·····?
+Answer: New York
+
+Category: Geography
+Question: Ankara is the capital of ······?
+Answer: Turkey
+
+Category: Geography
+Question: As what is Constantinople now known?
+Answer: Istanbul
+
+Category: Geography
+Question: As what is Formosa now known?
+Answer: Taiwan
+
+Category: Geography
+Question: As what is Krung Thep is more commonly known?
+Answer: Bangkok
+
+Category: Geography
+Question: As what is the South Pole also known?
+Answer: Amundsen Scott Station
+
+Category: Geography
+Question: As what was the Taj Mahal originally built?
+Answer: tomb
+
+Category: Geography
+Question: Austin is the capital of ······?
+Answer: Texas
+
+Category: Geography
+Question: Bamako is the capital of ······?
+Answer: Mali
+
+Category: Geography
+Question: Bangkok is the capital of ······?
+Answer: Thailand
+
+Category: Geography
+Question: Banjul is the capital of ······?
+Answer: Gambia
+
+Category: Geography
+Question: Bismarck is the capital of ······?
+Answer: North Dakota
+
+Category: Geography
+Question: Bissau is the capital of ······?
+Answer: Guinea-Bissau
+Regexp: Guinea[- ]Bissau
+
+Category: Geography
+Question: Bogota is the capital of ······?
+Answer: Colombia
+
+Category: Geography
+Question: Boise is the capital of ······?
+Answer: Idaho
+
+Category: Geography
+Question: Bridgetown is the capital of ······?
+Answer: Barbados
+
+Category: Geography
+Question: Budapest is the capital of ······?
+Answer: Hungary
+
+Category: Geography
+Question: Cheyenne is the capital of ······?
+Answer: Wyoming
+
+Category: Geography
+Question: Columbus is the capital of ······?
+Answer: Ohio
+
+Category: Geography
+Question: Dakar is the capital of ······?
+Answer: Senegal
+
+Category: Geography
+Question: Des Moines is the capital of ······?
+Answer: Iowa
+
+Category: Geography
+Question: Dhaka is the capital of ······?
+Answer: Bangladesh
+
+Category: Geography
+Question: Djibouti is the capital of ······?
+Answer: Djibouti
+
+Category: Geography
+Question: Five US states border which ocean?
+Answer: #Pacific# Ocean
+
+Category: Geography
+Question: Guatemala is the capital of ······?
+Answer: Guatemala
+
+Category: Geography
+Question: Helena is the capital of ······?
+Answer: Montana
+
+Category: Geography
+Question: How many Great Lakes are there?
+Answer: five
+Regexp: (five|5)
+
+Category: Geography
+Question: How many countries border the black sea?
+Answer: #six# - Turkey, Georgia, Russia, Ukraine, Romania and Bulgaria
+Regexp: (six|6)
+
+Category: Geography
+Question: If you flew due West from Portugal, what is the first continent you would reach?
+Answer: North America
+
+Category: Geography
+Question: In what state is Silicon Valley?
+Answer: California
+
+Category: Geography
+Question: In which city is Westminster Abbey?
+Answer: London
+
+Category: Geography
+Question: In which city is Westminster Abbey?
+Answer: London
+
+Category: Geography
+Question: In which city is the Arch of Hadrian?
+Answer: Athens
+
+Category: Geography
+Question: In which city is the famous Bond Street?
+Answer: London
+
+Category: Geography
+Question: In which country is Tobruk?
+Answer: Libya
+
+Category: Geography
+Question: In which country is the largest active volcano in the world?
+Answer: Ecuador
+
+Category: Geography
+Question: In which county are all ten of England's highest peaks?
+Answer: Cumbria
+
+Category: Geography
+Question: In which modern day country is ancient Troy?
+Answer: Turkey
+
+Category: Geography
+Question: In which state is Tupelo?
+Answer: Mississippi
+
+Category: Geography
+Question: In which state is the Natchez Trail?
+Answer: Mississippi
+
+Category: Geography
+Question: Into what ocean does the Zambezi River empty?
+Answer: #Indian# Ocean
+
+Category: Geography
+Question: Into which bay does the Golden Gate Strait lead?
+Answer: #San Francisco# Bay
+
+Category: Geography
+Question: Into which estuary do the Trent and Ouse flow?
+Answer: Humber
+
+Category: Geography
+Question: Is Belfast in Northern or Southern Ireland?
+Answer: Northern
+
+Category: Geography
+Question: Is Dublin in Northern or Southern ireland?
+Answer: Southern
+
+Category: Geography
+Question: Jefferson City is the capital of ······?
+Answer: Missouri
+
+Category: Geography
+Question: Kathmandu is the capital of ······?
+Answer: Nepal
+
+Category: Geography
+Question: Kigali is the capital of ······?
+Answer: Rwanda
+
+Category: Geography
+Question: Kingston is the capital of ······?
+Answer: Jamaica
+
+Category: Geography
+Question: Kinshasa is the capital of ······?
+Answer: Democratic Republic of the Congo
+Regexp: (democratic republic of the congo|congo)
+
+Category: Geography
+Question: Kuwait City is the capital of ······?
+Answer: Kuwait
+
+Category: Geography
+Question: Lansing is the capital of ······?
+Answer: Michigan
+
+Category: Geography
+Question: Libreville is the capital of ······?
+Answer: Gabon
+
+Category: Geography
+Question: Lilongwe is the capital of ······?
+Answer: Malawi
+
+Category: Geography
+Question: Lome is the capital of ······?
+Answer: Togo
+
+Category: Geography
+Question: Luxembourg is the capital of ······?
+Answer: Luxembourg
+
+Category: Geography
+Question: Malabo is the capital of ······?
+Answer: Equatorial Guinea
+
+Category: Geography
+Question: Mayfair, London is a district of little streets near ······?
+Answer: Hyde Park
+
+Category: Geography
+Question: Mexico City is the capital of ······?
+Answer: Mexico
+
+Category: Geography
+Question: Montevideo is the capital of ······?
+Answer: Uruguay
+
+Category: Geography
+Question: Nashville is the capital of ······?
+Answer: Tennessee
+
+Category: Geography
+Question: Near what river is the Temple of Karnak?
+Answer: Nile
+
+Category: Geography
+Question: New Delhi is the capital of ······?
+Answer: India
+
+Category: Geography
+Question: Nicosia is the capital of ······?
+Answer: Cyprus
+
+Category: Geography
+Question: Of what are Quemoy and Matsu part?
+Answer: Taiwan
+
+Category: Geography
+Question: Of which country does the Kalahari Desert cover 84%?
+Answer: Botswana
+
+Category: Geography
+Question: On the London Underground, which station has a different name on two of its platforms?
+Answer: Bank and Monument
+Regexp: (Bank (and|&) Monument|Monument (and|&) Bank)
+
+Category: Geography
+Question: On the banks of which river is the Taj Mahal?
+Answer: River #Jumna#
+
+Category: Geography
+Question: On what island is Pearl Harbor?
+Answer: Oahu
+
+Category: Geography
+Question: On what river is Blackpool?
+Answer: River #Fylde#
+
+Category: Geography
+Question: On what river is Liverpool?
+Answer: Mersey
+
+Category: Geography
+Question: On what sea is the Crimea?
+Answer: Black Sea
+
+Category: Geography
+Question: On which coast of Australia is Sydney?
+Answer: East
+
+Category: Geography
+Question: Port Louis is the capital of ······?
+Answer: Mauritius
+
+Category: Geography
+Question: Port Moresby is the capital of ······?
+Answer: Papua New Guinea
+
+Category: Geography
+Question: Raleigh is the capital of ······?
+Answer: North Carolina
+
+Category: Geography
+Question: Richmond is the capital of ······?
+Answer: Virginia
+
+Category: Geography
+Question: Riyadh is the capital of ····Minneapolis and Saint Paul
+Regexp: (Minneapolis (and |& ) S(ain)?t.? Paul|S(ain)?t.? Paul (and |& )Minneapolis)
+
+Category: United States
+Question: Who is the only man to have been both chief justice and president of the US?
+Answer: William #Taft#
+
+Category: United States
+Question: Who was Al Gore's freshman roommate at Harvard?
+Answer: Tommy Lee Jones
+
+Category: United States
+Question: Who was Tommy Lee Jones' freshman roommate at Harvard?
+Answer: Al Gore
+
+Category: United States
+Question: Who was born Anne Frances Robbins?
+Answer: Nancy Davis Reagan
+
+Category: United States
+Question: Who was born Sarah Jane Fulks?
+Answer: Jane Wyman Reagan
+
+Category: United States
+Question: Who was the first black mayor of Chicago?
+Answer: Harold Washington
+
+Category: United states
+Question: What was Jane Wyman Reagan's birth name?
+Answer: Sarah Jane Fulks
+
+Category: Ventilation
+Question: If locked in a completely sealed room, of what will you die before you suffocate?
+Answer: carbon monoxide poisoning
+
+Category: Very Big Guns
+Question: Where is the biggest calibre cannon?
+Answer: Kremlin
+
+Category: Weather
+Question: Approximately how many times a minute does lightning strike the earth?
+Answer: six thousand
+Regexp: (six thousand|6[, ]?000)
+
+Category: Weather
+Question: Which US state holds the record for most snowfall in a day, recorded February 7, 1916?
+Answer: Alaska
+
+Category: What is it?
+Question: What is 9 metres high, 7 metres wide and 2,500 kilometres long?
+Answer: Great Wall of China
+
+Category: Wines
+Question: Good Rhine wines are bottled in what colour bottles?
+Answer: brown
+
+Category: Woodchucks
+Question: How much wood can a woodchuck chuck if a woodchuck could chuck wood?
+Answer: All the wood that a woodchuck could if a woodchuck could chuck wood
+
+Category: Word Association
+Question: Which word is related to these three: rat, blue, cottage?
+Answer: cheese
+
+Category: Word Pairs
+Question: Cattle are bovine, sheep are ······ ?
+Answer: ovine
+
+Category: Words containing 'for'
+Question: Pardon?
+Answer: FORgive
+
+Category: World Affairs
+Question: What arabian peninsula nations recently merged under communist leadership?
+Answer: Yemen
+
+Category: World Climate
+Question: What is a calm ocean region near the equator called?
+Answer: doldrums
+
+Question: Which two teams automatically qualified for the France '98 soccer world cup?
+Answer: France and Brazil
+Regexp: (France (and|&) Brazil|Brazil (and|&) France)


### PR DESCRIPTION
Include a simple Trivia plugin for the fun of all.

Quick plugin that will orchestrate a fun game of trivia. Sourced of about 1000 questions, to be asked. Made in a means that trivia can be run on different channels if Phergie is set to act on different channels. Allows users to customize number of rounds, and time delays between questions, and if answers are given at the end of the time.

(had a previous PR that got mucked up with a poorly done rebase.  this is cleaner)
