### PR TITLE
Support getUsername

### DIFF
--- a/Phergie/Event/Request.php
+++ b/Phergie/Event/Request.php
@@ -541,6 +541,16 @@ class Phergie_Event_Request
     }
 
     /**
+     * Returns the username of the user who originated the event.
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->getHostmask()->getUsername();
+    }
+
+    /**
      * Determines whether a given string is a valid IRC channel name.
      *
      * @param string $string String to analyze


### PR DESCRIPTION
Add support in request to pull the username of the user making an event.  Useful if you don't care about what the persons nick is at the time, but rather the underlying login name.  Example is a IRC server that uses LDAP or something for username storage, so it's more static than a nickname can be.
